### PR TITLE
Add get/set for sample event

### DIFF
--- a/src/components/LeafletMap.jsx
+++ b/src/components/LeafletMap.jsx
@@ -25,7 +25,7 @@ const isValidLatLng = (lat, lng) => {
 }
 
 const isValidZoom = (zoom) => {
-  return zoom >= 0 && zoom <= 20
+  return zoom >= 0 && zoom <= 20 && zoom !== null
 }
 
 export default function LeafletMap(props) {


### PR DESCRIPTION
http://localhost:3030/?lng=-87.83822536468507&zoom=14&lat=18.158738101167376&sample_event_id=0b1637a4-df32-4167-ba37-b21bc9717b5b

If a sample event is selected, the url params is updated with that sample event's id

If a url is loaded that contains a sample event id, the selected marker will be used to display that sample event on the map