### PR TITLE
Put sites column before transects column

### DIFF
--- a/src/components/TableView.jsx
+++ b/src/components/TableView.jsx
@@ -87,14 +87,14 @@ const TableView = (props) => {
         sortType: reactTableNaturalSort,
       },
       {
-        Header: 'Transects',
-        accessor: 'transects',
+        Header: 'Sites',
+        accessor: 'siteCount',
         sortType: reactTableNaturalSort,
         align: 'right',
       },
       {
-        Header: 'Sites',
-        accessor: 'siteCount',
+        Header: 'Transects',
+        accessor: 'transects',
         sortType: reactTableNaturalSort,
         align: 'right',
       },
@@ -109,8 +109,8 @@ const TableView = (props) => {
         formattedYears,
         countries,
         organizations,
-        transects,
         siteCount,
+        transects,
         rawProjectData,
       } = data
 
@@ -119,8 +119,8 @@ const TableView = (props) => {
         formattedYears,
         countries,
         organizations,
-        transects,
         siteCount,
+        transects,
         rawProjectData,
       }
     })


### PR DESCRIPTION
Reorganize the sites column to come before the transects column in table view

I realize that the styling of the table is messed up, but I fixed it in M885 PR. This change will not conflict with that styling change