### PR TITLE
M830

### DIFF
--- a/src/components/FilterPane/FilterPane.jsx
+++ b/src/components/FilterPane/FilterPane.jsx
@@ -400,7 +400,7 @@ const FilterPane = ({ mermaidUserData }) => {
                       htmlFor={`checkbox-${project.project_id}`}
                       onClick={(e) => e.stopPropagation()}
                     >
-                      {project.records[0]?.project_name}{' '}
+                      {project.project_name}{' '}
                       {userIsMemberOfProject(project.project_id, mermaidUserData) && <IconUser />}
                     </StyledLabel>
                   </StyledClickableArea>

--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -25,8 +25,14 @@ import {
 } from './MermaidDash.styles'
 
 const MermaidDash = () => {
-  const { projectData, displayedProjects, setProjectData, mermaidUserData, setMermaidUserData } =
-    useFilterProjectsContext()
+  const {
+    projectData,
+    displayedProjects,
+    setProjectData,
+    mermaidUserData,
+    setMermaidUserData,
+    setCheckedProjects,
+  } = useFilterProjectsContext()
   const [showFilterPane, setShowFilterPane] = useState(true)
   const [showFilterModal, setShowFilterModal] = useState(false)
   const [showMetricsPane, setShowMetricsPane] = useState(true)
@@ -74,13 +80,17 @@ const MermaidDash = () => {
                 : [...data.results],
             }
           })
+          setCheckedProjects((prevCheckedProjects) => [
+            ...prevCheckedProjects,
+            ...data.results.map((project) => project.project_id),
+          ])
           nextPageUrl = data.next
         }
       } catch (error) {
         console.error('Error fetching data:', error)
       }
     },
-    [setProjectData],
+    [setProjectData, setCheckedProjects],
   )
 
   const fetchUserProfile = useCallback(async () => {

--- a/src/context/FilterProjectsContext.jsx
+++ b/src/context/FilterProjectsContext.jsx
@@ -243,10 +243,7 @@ export const FilterProjectsProvider = ({ children }) => {
           // Filter by project name
           const matchesProjectName =
             projectNameFilter === '' ||
-            project.records[0]?.project_name.toLowerCase().includes(projectNameFilter.toLowerCase())
-
-          // Filter out projects with empty records
-          const nonEmptyRecords = project.records.length > 0
+            project.project_name.toLowerCase().includes(projectNameFilter.toLowerCase())
 
           // Filter out projects that the user is not a member of
           const onlyShowProjectsUserIsAMemberOf = showYourData
@@ -257,7 +254,6 @@ export const FilterProjectsProvider = ({ children }) => {
             matchesSelectedCountries &&
             matchesSelectedOrganizations &&
             matchesProjectName &&
-            nonEmptyRecords &&
             onlyShowProjectsUserIsAMemberOf
 
           return isProjectVisible
@@ -282,18 +278,13 @@ export const FilterProjectsProvider = ({ children }) => {
     }
 
     const filteredProjects = applyFilterToProjects(selectedCountries, selectedOrganizations)
-    const filteredIds = new Set(filteredProjects.map((project) => project.project_id))
     const paramsSampleEventId =
       queryParams.has('sample_event_id') && queryParams.get('sample_event_id')
     doesSelectedSampleEventPassFilters(paramsSampleEventId, filteredProjects)
-    setCheckedProjects([...filteredIds])
 
     setDisplayedProjects(
-      filteredProjects.sort((a, b) =>
-        a.records[0]?.project_name.localeCompare(b.records[0]?.project_name),
-      ),
+      filteredProjects.sort((a, b) => a.project_name.localeCompare(b.project_name)),
     )
-    setCheckedProjects([...filteredIds])
     if (projectData.results.length === projectData.count) {
       setAllProjectsFinishedFiltering(true)
     }

--- a/src/helperFunctions/formatProjectDataHelper.js
+++ b/src/helperFunctions/formatProjectDataHelper.js
@@ -19,12 +19,17 @@ export const formatProjectDataHelper = (project) => {
   })
 
   const years = [...data.years].sort((a, b) => a.localeCompare(b))
-  const formattedYears = years.length === 1 ? years[0] : `${years[0]}-${years[years.length - 1]}`
+  const formattedYears =
+    years.length === 0
+      ? ''
+      : years.length === 1
+        ? years[0]
+        : `${years[0]}-${years[years.length - 1]}`
   const countries = [...data.countries].sort((a, b) => a.localeCompare(b)).join(', ')
   const organizations = [...data.organizations].sort((a, b) => a.localeCompare(b)).join(', ')
 
   return {
-    projectName: records[0].project_name,
+    projectName: project.project_name,
     formattedYears,
     countries,
     organizations,


### PR DESCRIPTION
Kim has updated the endpoint to include the project's name alongside the `project_id` and `record keys`. Now we can populate the project's name without accessing the project's first record. This also solved the situation where if a project did not have any records, then it wouldn't be possible to get the project name (and would previously show as ' Project with no name')

All projects are displayed now, regardless if they have 0 records or not. This is so that the table view can display all available projects

There is a bug in the backend where it shows every project's name as 'awaiting refresh' which will be fixed later. After it is fixed the project name will show properly on the front end, so it will just look incorrect for now

This PR also included a fix for the behaviour of the checkboxes beside the project names. Unchecking a project's checkbox now correctly removes the data points associated with that project from the map. Checking it again adds those data points back to the map