### PR TITLE
Update sites to surveys, calculate surveys and transects

### DIFF
--- a/src/components/MapAndTableControls/components/ViewToggle.jsx
+++ b/src/components/MapAndTableControls/components/ViewToggle.jsx
@@ -54,11 +54,11 @@ const ViewToggle = ({ view, setView }) => {
     { label: 'Countries', key: 'countries' },
     { label: 'Organizations', key: 'organizations' },
     { label: 'Transects', key: 'transects' },
-    { label: 'Sites', key: 'siteCount' },
+    { label: 'Surveys', key: 'surveyCount' },
   ]
 
   const tableContent = displayedProjects.map((project) => {
-    const { projectName, formattedYears, countries, organizations, siteCount } =
+    const { projectName, formattedYears, countries, organizations, surveyCount, transects } =
       formatProjectDataHelper(project)
     const formattedTableRowData = {
       projectName,
@@ -66,7 +66,8 @@ const ViewToggle = ({ view, setView }) => {
       countries,
       organizations,
       recordCount: project.records.length,
-      siteCount,
+      surveyCount,
+      transects,
     }
     return formattedTableRowData
   })

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -7,7 +7,7 @@ import {
   MetricsCard,
   P,
   H3,
-  SitesAndTransectsContainer,
+  SurveysAndTransectsContainer,
   MobileExpandedMetricsPane,
   DesktopToggleMetricsPaneButton,
   MobileExpandMetricsPaneButton,
@@ -21,7 +21,7 @@ const MetricsPane = ({
   setShowMetricsPane,
   showLoadingIndicator,
 }) => {
-  const [numSites, setNumSites] = useState(0)
+  const [numSurveys, setNumSurveys] = useState(0)
   const [numTransects, setNumTransects] = useState(0)
   const [numUniqueCountries, setNumUniqueCountries] = useState(0)
   const [yearRange, setYearRange] = useState('')
@@ -29,7 +29,7 @@ const MetricsPane = ({
   const { isMobileWidth, isDesktopWidth } = useResponsive()
 
   const calculateMetrics = useMemo(() => {
-    let sites = new Set()
+    let surveys = new Set()
     let transects = 0
     let countries = new Set()
     let years = new Set()
@@ -40,7 +40,7 @@ const MetricsPane = ({
           transects += value.sample_unit_count
         })
         countries.add(record.country_name)
-        sites.add(record.site_name)
+        surveys.add(record.site_name)
         years.add(record.sample_date.split('-')[0])
       })
     })
@@ -54,7 +54,7 @@ const MetricsPane = ({
           : `Showing data from ${sortedYears[0]} to ${sortedYears[sortedYears.length - 1]}`
 
     return {
-      numSites: sites.size,
+      numSurveys: surveys.size,
       numTransects: transects,
       numUniqueCountries: countries.size,
       yearRange,
@@ -62,8 +62,8 @@ const MetricsPane = ({
   }, [displayedProjects])
 
   const _setMetricsAfterCalculating = useEffect(() => {
-    const { numSites, numTransects, numUniqueCountries, yearRange } = calculateMetrics
-    setNumSites(numSites)
+    const { numSurveys, numTransects, numUniqueCountries, yearRange } = calculateMetrics
+    setNumSurveys(numSurveys)
     setNumTransects(numTransects)
     setNumUniqueCountries(numUniqueCountries)
     setYearRange(yearRange)
@@ -98,16 +98,16 @@ const MetricsPane = ({
             <P>{displayedProjects.length}</P>
             <H3>Projects </H3>
           </MetricsCard>
-          <SitesAndTransectsContainer>
+          <SurveysAndTransectsContainer>
             <MetricsCard>
-              <P>{numSites}</P>
-              <H3>Sites</H3>
+              <P>{numSurveys}</P>
+              <H3>Surveys</H3>
             </MetricsCard>
             <MetricsCard>
               <P>{numTransects}</P>
               <H3>Transects</H3>
             </MetricsCard>
-          </SitesAndTransectsContainer>
+          </SurveysAndTransectsContainer>
           {isDesktopWidth ? (
             <MetricsCard>
               <P>{yearRange}</P>

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -29,7 +29,7 @@ const MetricsPane = ({
   const { isMobileWidth, isDesktopWidth } = useResponsive()
 
   const calculateMetrics = useMemo(() => {
-    let surveys = new Set()
+    let surveys = 0
     let transects = 0
     let countries = new Set()
     let years = new Set()
@@ -40,9 +40,9 @@ const MetricsPane = ({
           transects += value.sample_unit_count
         })
         countries.add(record.country_name)
-        surveys.add(record.site_name)
         years.add(record.sample_date.split('-')[0])
       })
+      surveys += project.records.length
     })
 
     const sortedYears = Array.from(years).sort()
@@ -54,7 +54,7 @@ const MetricsPane = ({
           : `Showing data from ${sortedYears[0]} to ${sortedYears[sortedYears.length - 1]}`
 
     return {
-      numSurveys: surveys.size,
+      numSurveys: surveys,
       numTransects: transects,
       numUniqueCountries: countries.size,
       yearRange,

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -109,7 +109,7 @@ export const MobileExpandMetricsPaneButton = styled(ButtonSecondary)`
   `)}
 `
 
-export const SitesAndTransectsContainer = styled('div')`
+export const SurveysAndTransectsContainer = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/TableView/TableView.jsx
+++ b/src/components/TableView/TableView.jsx
@@ -41,7 +41,7 @@ const TableView = ({ view, setView }) => {
 
   const _getSiteRecords = useEffect(() => {
     const formattedTableData = displayedProjects.map((project, i) => {
-      const { projectName, formattedYears, countries, organizations, siteCount } =
+      const { projectName, formattedYears, countries, organizations, surveyCount, transects } =
         formatProjectDataHelper(project)
       return {
         id: i,
@@ -49,8 +49,8 @@ const TableView = ({ view, setView }) => {
         formattedYears,
         countries,
         organizations,
-        transects: project.records.length,
-        siteCount,
+        transects,
+        surveyCount,
         rawProjectData: project,
       }
     })
@@ -81,8 +81,8 @@ const TableView = ({ view, setView }) => {
         sortType: reactTableNaturalSort,
       },
       {
-        Header: 'Sites',
-        accessor: 'siteCount',
+        Header: 'Surveys',
+        accessor: 'surveyCount',
         sortType: reactTableNaturalSort,
         align: 'right',
       },
@@ -103,7 +103,7 @@ const TableView = ({ view, setView }) => {
         formattedYears,
         countries,
         organizations,
-        siteCount,
+        surveyCount,
         transects,
         rawProjectData,
       } = data
@@ -113,7 +113,7 @@ const TableView = ({ view, setView }) => {
         formattedYears,
         countries,
         organizations,
-        siteCount,
+        surveyCount,
         transects,
         rawProjectData,
       }

--- a/src/helperFunctions/formatProjectDataHelper.js
+++ b/src/helperFunctions/formatProjectDataHelper.js
@@ -11,9 +11,7 @@ export const formatProjectDataHelper = (project) => {
   records.forEach((record) => {
     data.years.add(record.sample_date.substring(0, 4))
     data.countries.add(record.country_name)
-    if (record.tags) {
-      record.tags.forEach((tag) => data.organizations.add(tag.name))
-    }
+    record.tags?.forEach((tag) => data.organizations.add(tag.name))
     const sumOfSampleUnitCounts = Object.values(record.protocols).reduce((sum, protocol) => {
       return sum + protocol.sample_unit_count
     }, 0)

--- a/src/helperFunctions/formatProjectDataHelper.js
+++ b/src/helperFunctions/formatProjectDataHelper.js
@@ -12,6 +12,14 @@ export const formatProjectDataHelper = (project) => {
   ]
     .sort((a, b) => a.localeCompare(b))
     .join(', ')
-  const siteCount = [...new Set(project.records.map((record) => record.site_name))].length
-  return { projectName, formattedYears, countries, organizations, siteCount }
+  const surveyCount = project.records.length
+  const transects = project.records.reduce((acc, record) => {
+    return (
+      acc +
+      Object.values(record.protocols).reduce((acc, protocol) => {
+        return acc + protocol.sample_unit_count
+      }, 0)
+    )
+  }, 0)
+  return { projectName, formattedYears, countries, organizations, surveyCount, transects }
 }

--- a/src/helperFunctions/formatProjectDataHelper.js
+++ b/src/helperFunctions/formatProjectDataHelper.js
@@ -1,25 +1,36 @@
 export const formatProjectDataHelper = (project) => {
-  const projectName = project.records[0].project_name
-  const years = [
-    ...new Set(project.records.map((record) => record.sample_date.substring(0, 4))),
-  ].sort((a, b) => a.localeCompare(b))
+  const { records } = project
+  const data = {
+    years: new Set(),
+    countries: new Set(),
+    organizations: new Set(),
+    surveyCount: records.length,
+    transects: 0,
+  }
+
+  records.forEach((record) => {
+    data.years.add(record.sample_date.substring(0, 4))
+    data.countries.add(record.country_name)
+    if (record.tags) {
+      record.tags.forEach((tag) => data.organizations.add(tag.name))
+    }
+    const sumOfSampleUnitCounts = Object.values(record.protocols).reduce((sum, protocol) => {
+      return sum + protocol.sample_unit_count
+    }, 0)
+    data.transects += sumOfSampleUnitCounts
+  })
+
+  const years = [...data.years].sort((a, b) => a.localeCompare(b))
   const formattedYears = years.length === 1 ? years[0] : `${years[0]}-${years[years.length - 1]}`
-  const countries = [...new Set(project.records.map((record) => record.country_name))]
-    .sort((a, b) => a.localeCompare(b))
-    .join(', ')
-  const organizations = [
-    ...new Set(project.records.map((record) => record.tags?.map((tag) => tag.name)).flat()),
-  ]
-    .sort((a, b) => a.localeCompare(b))
-    .join(', ')
-  const surveyCount = project.records.length
-  const transects = project.records.reduce((acc, record) => {
-    return (
-      acc +
-      Object.values(record.protocols).reduce((acc, protocol) => {
-        return acc + protocol.sample_unit_count
-      }, 0)
-    )
-  }, 0)
-  return { projectName, formattedYears, countries, organizations, surveyCount, transects }
+  const countries = [...data.countries].sort((a, b) => a.localeCompare(b)).join(', ')
+  const organizations = [...data.organizations].sort((a, b) => a.localeCompare(b)).join(', ')
+
+  return {
+    projectName: records[0].project_name,
+    formattedYears,
+    countries,
+    organizations,
+    surveyCount: data.surveyCount,
+    transects: data.transects,
+  }
 }


### PR DESCRIPTION
Update "sites" labels to "surveys"
Calculate surveys as a project's `records.length`
Properly calculate transects by summing up a project's `sample_unit_count` across all sample events