### PR TITLE
Fix/map performance

### DIFF
--- a/src/components/LeafletMap.jsx
+++ b/src/components/LeafletMap.jsx
@@ -194,7 +194,7 @@ const LeafletMap = ({ showFilterPane, showMetricsPane, view, setView }) => {
       <MapAndTableControlsWrapper />
       <MarkerClusterGroup
         // TODO: Experiment with some of the "chunked" props to see if they improve performance: https://akursat.gitbook.io/marker-cluster/api
-        chunkedLoading
+        chunkedLoading={true}
         spiderfyOnMaxZoom={false}
         onClick={(event) => {
           console.log('Click marker cluster group', event)

--- a/src/components/LeafletMap.jsx
+++ b/src/components/LeafletMap.jsx
@@ -194,7 +194,8 @@ const LeafletMap = ({ showFilterPane, showMetricsPane, view, setView }) => {
       <MapAndTableControlsWrapper />
       <MarkerClusterGroup
         // TODO: Experiment with some of the "chunked" props to see if they improve performance: https://akursat.gitbook.io/marker-cluster/api
-        chunkedLoading={true}
+        chunkedLoading
+        chunkedInterval={2000}
         spiderfyOnMaxZoom={false}
         onClick={(event) => {
           console.log('Click marker cluster group', event)

--- a/src/components/LeafletMap.jsx
+++ b/src/components/LeafletMap.jsx
@@ -126,7 +126,8 @@ const LeafletMap = ({ showFilterPane, showMetricsPane, view, setView }) => {
   )
 
   const _addAndRemoveMarkersBasedOnFilters = useEffect(() => {
-    const displayedProjectsChanged = displayedProjects !== prevDisplayedProjects
+    const displayedProjectsChanged =
+      JSON.stringify(displayedProjects) !== JSON.stringify(prevDisplayedProjects)
     const selectedMarkerChanged = selectedMarkerId !== prevSelectedMarkerId
     const checkedProjectsChanged = checkedProjects !== prevCheckedProjects
 
@@ -174,11 +175,8 @@ const LeafletMap = ({ showFilterPane, showMetricsPane, view, setView }) => {
   }, [
     displayedProjects,
     prevDisplayedProjects,
-    queryParams,
     selectedMarkerId,
     prevSelectedMarkerId,
-    updateURLParams,
-    setSelectedMarkerId,
     checkedProjects,
     prevCheckedProjects,
     handleClickCircleMarker,


### PR DESCRIPTION
Fixed an issue where whenever the user zooms out of the map it would take a long time for the map to become responsive again. I found part of the issue was that displayedProjectsChanged was equal to true on zoom out (even though displayedProjects and prevDisplayedProjects didn't actually change), thus causing all the markers to be re-rendered. Converting them both to strings and then comparing them makes displayedProjectsChanged to be false, which would not unnecessarily re-render the markers

Also set chunkedLoading to be true as I noticed a small performance improvement when the map first loaded and it would let the user interact with the filter pane without having to wait so long

