### PR TITLE
Change map maxZoom

### DIFF
--- a/src/components/LeafletMap.jsx
+++ b/src/components/LeafletMap.jsx
@@ -187,7 +187,7 @@ const LeafletMap = ({ showFilterPane, showMetricsPane, view, setView }) => {
       center={mapCenter}
       zoom={mapZoom}
       scrollWheelZoom={true}
-      maxZoom={20}
+      maxZoom={18}
       ref={setMap}
     >
       <MapEventListener />


### PR DESCRIPTION
Change the map's max zoom to 18 as zoom levels 19 and 20 tend to not have any tile data and is therefore not useful to the user