### PR TITLE
M871

### DIFF
--- a/src/components/MaplibreMap.jsx
+++ b/src/components/MaplibreMap.jsx
@@ -96,8 +96,14 @@ const sitesSource = {
 }
 
 const MaplibreMap = ({ view, setView }) => {
-  const { displayedProjects, selectedMarkerId, setSelectedMarkerId, checkedProjects } =
-    useFilterProjectsContext()
+  const {
+    displayedProjects,
+    selectedMarkerId,
+    setSelectedMarkerId,
+    checkedProjects,
+    enableFollowScreen,
+    setMapBbox,
+  } = useFilterProjectsContext()
   const prevDisplayedProjects = usePrevious(displayedProjects)
   const location = useLocation()
   const navigate = useNavigate()
@@ -141,6 +147,15 @@ const MaplibreMap = ({ view, setView }) => {
     //   map.zoomControl.remove()
     // }
   }
+
+  const _updateMapBbox = useEffect(() => {
+    if (!enableFollowScreen) {
+      return
+    }
+    const map = mapRef.current?.getMap()
+    const bounds = map.getBounds()
+    setMapBbox(bounds)
+  }, [enableFollowScreen])
 
   const _addAndRemoveMarkersBasedOnFilters = useEffect(() => {
     const displayedProjectsChanged =
@@ -187,6 +202,7 @@ const MaplibreMap = ({ view, setView }) => {
     const { lat, lng } = map.getCenter()
     const zoom = map.getZoom()
     const queryParams = getURLParams()
+    const bounds = map.getBounds()
 
     queryParams.set('lat', lat)
     queryParams.set('lng', lng)
@@ -194,6 +210,7 @@ const MaplibreMap = ({ view, setView }) => {
     updateURLParams(queryParams)
     setMapCenter([lat, lng])
     setMapZoom(zoom)
+    setMapBbox(bounds)
   }
 
   const handleResize = () => {
@@ -288,6 +305,9 @@ const MaplibreMap = ({ view, setView }) => {
       }
       customImage.src = customIcon
       hideMapStyleLayers(map)
+
+      const bounds = map.getBounds()
+      setMapBbox(bounds)
     }
   }
 

--- a/src/components/MaplibreMap.jsx
+++ b/src/components/MaplibreMap.jsx
@@ -149,13 +149,13 @@ const MaplibreMap = ({ view, setView }) => {
   }
 
   const _updateMapBbox = useEffect(() => {
-    if (!enableFollowScreen) {
+    const map = mapRef.current?.getMap()
+    if (!enableFollowScreen || !map) {
       return
     }
-    const map = mapRef.current?.getMap()
     const bounds = map.getBounds()
     setMapBbox(bounds)
-  }, [enableFollowScreen])
+  }, [enableFollowScreen, setMapBbox])
 
   const _addAndRemoveMarkersBasedOnFilters = useEffect(() => {
     const displayedProjectsChanged =

--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -247,6 +247,7 @@ const MermaidDash = () => {
       showMetricsPane={showMetricsPane}
       setShowMetricsPane={setShowMetricsPane}
       showLoadingIndicator={showLoadingIndicator}
+      view={view}
     />
   )
 

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -33,6 +33,7 @@ import {
   StyledReefItemBold,
   StyledVisibleBackground,
   StyledChevronSpan,
+  DesktopFollowScreenButton,
 } from './MetricsPane.styles'
 import { useFilterProjectsContext } from '../../context/FilterProjectsContext'
 import { CloseButton } from '../generic'
@@ -41,7 +42,7 @@ import mapPin from '../../assets/map-pin.png'
 import coralReefSvg from '../../assets/coral_reef.svg'
 import { IconPersonCircle } from '../../assets/dashboardOnlyIcons'
 
-const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator }) => {
+const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator, view }) => {
   const [numSurveys, setNumSurveys] = useState(0)
   const [numTransects, setNumTransects] = useState(0)
   const [numUniqueCountries, setNumUniqueCountries] = useState(0)
@@ -58,6 +59,8 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
     userIsMemberOfProject,
     checkedProjects,
     getActiveProjectCount,
+    enableFollowScreen,
+    setEnableFollowScreen,
   } = useFilterProjectsContext()
   const [selectedSampleEvent, setSelectedSampleEvent] = useState(null)
   const [metricsView, setMetricsView] = useState('summary')
@@ -320,6 +323,10 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
     }
   }
 
+  const handleFollowScreen = () => {
+    setEnableFollowScreen((prevState) => !prevState)
+  }
+
   return (
     <StyledMetricsWrapper
       $showMetricsPane={showMetricsPane}
@@ -330,6 +337,17 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
       {isMobileWidth || showMetricsPane ? MetricsContent() : null}
       {isMobileWidth && showMobileExpandedMetricsPane ? (
         <MobileExpandedMetricsPane>Placeholder: more metrics here</MobileExpandedMetricsPane>
+      ) : null}
+      {isDesktopWidth && view === 'mapView' && showMetricsPane ? (
+        <DesktopFollowScreenButton>
+          <input
+            type="checkbox"
+            id="follow-screen"
+            checked={enableFollowScreen}
+            onChange={handleFollowScreen}
+          />
+          <label htmlFor="follow-screen">Update metrics based on map view</label>
+        </DesktopFollowScreenButton>
       ) : null}
       {isDesktopWidth ? (
         <DesktopToggleMetricsPaneButton onClick={handleShowMetricsPane}>

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -34,6 +34,7 @@ import {
   StyledVisibleBackground,
   StyledChevronSpan,
   DesktopFollowScreenButton,
+  StyledLabel,
 } from './MetricsPane.styles'
 import { useFilterProjectsContext } from '../../context/FilterProjectsContext'
 import { CloseButton } from '../generic'
@@ -362,9 +363,9 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
             onChange={handleFollowScreen}
             onClick={(e) => e.stopPropagation()}
           />
-          <label htmlFor="follow-screen" onClick={(e) => e.stopPropagation()}>
+          <StyledLabel htmlFor="follow-screen" onClick={(e) => e.stopPropagation()}>
             Update metrics based on map view
-          </label>
+          </StyledLabel>
         </DesktopFollowScreenButton>
       ) : null}
       {isDesktopWidth ? (

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -323,8 +323,17 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
     }
   }
 
-  const handleFollowScreen = () => {
+  const handleFollowScreen = (e) => {
     setEnableFollowScreen((prevState) => !prevState)
+
+    const { checked } = e.target
+    const queryParams = getURLParams()
+    if (checked) {
+      queryParams.set('follow_screen', 'true')
+    } else {
+      queryParams.delete('follow_screen')
+    }
+    updateURLParams(queryParams)
   }
 
   return (
@@ -338,15 +347,24 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, showLoadingIndicator
       {isMobileWidth && showMobileExpandedMetricsPane ? (
         <MobileExpandedMetricsPane>Placeholder: more metrics here</MobileExpandedMetricsPane>
       ) : null}
-      {isDesktopWidth && view === 'mapView' && showMetricsPane ? (
-        <DesktopFollowScreenButton>
+      {isDesktopWidth && view === 'mapView' && showMetricsPane && !selectedMarkerId ? (
+        <DesktopFollowScreenButton
+          onClick={() =>
+            handleFollowScreen({
+              target: { checked: !enableFollowScreen },
+            })
+          }
+        >
           <input
             type="checkbox"
             id="follow-screen"
             checked={enableFollowScreen}
             onChange={handleFollowScreen}
+            onClick={(e) => e.stopPropagation()}
           />
-          <label htmlFor="follow-screen">Update metrics based on map view</label>
+          <label htmlFor="follow-screen" onClick={(e) => e.stopPropagation()}>
+            Update metrics based on map view
+          </label>
         </DesktopFollowScreenButton>
       ) : null}
       {isDesktopWidth ? (
@@ -380,6 +398,7 @@ MetricsPane.propTypes = {
   showMetricsPane: PropTypes.bool.isRequired,
   setShowMetricsPane: PropTypes.func.isRequired,
   showLoadingIndicator: PropTypes.bool.isRequired,
+  view: PropTypes.oneOf(['mapView', 'tableView']).isRequired,
 }
 
 export default MetricsPane

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -279,3 +279,17 @@ export const StyledVisibleBackground = styled.div`
 export const StyledChevronSpan = styled.span`
   padding-left: 0.8rem;
 `
+
+export const DesktopFollowScreenButton = styled(ButtonSecondary)`
+  position: absolute;
+  top: 1.3rem;
+  left: -42rem;
+  height: 6rem;
+  z-index: 5;
+  width: 31rem;
+  border: solid 1px ${theme.color.secondaryBorder}
+  background-color: ${theme.color.grey1};
+  ${mediaQueryTabletLandscapeOnly(css`
+    display: none;
+  `)}
+`

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -293,3 +293,7 @@ export const DesktopFollowScreenButton = styled(ButtonSecondary)`
     display: none;
   `)}
 `
+
+export const StyledLabel = styled.label`
+  cursor: pointer;
+`

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -6,6 +6,7 @@ export const URL_PARAMS = {
   SAMPLE_DATE_BEFORE: 'sample_date_before',
   PROJECTS: 'projects',
   METHOD_DATA_SHARING: 'omitted_method_data_sharing',
+  FOLLOW_SCREEN: 'follow_screen',
 }
 
 export const COLLECTION_METHODS = {

--- a/src/context/FilterProjectsContext.jsx
+++ b/src/context/FilterProjectsContext.jsx
@@ -178,6 +178,7 @@ export const FilterProjectsProvider = ({ children }) => {
     const showYourDataOnly = showYourData
     const anyInactiveMethodDataSharing = methodDataSharingFilters.length > 0
     const anyActiveProjects = projectNameFilter
+    const followScreenEnabled = enableFollowScreen
 
     return (
       anyActiveCountries ||
@@ -186,7 +187,8 @@ export const FilterProjectsProvider = ({ children }) => {
       anyActiveSampleDateBefore ||
       showYourDataOnly ||
       anyInactiveMethodDataSharing ||
-      anyActiveProjects
+      anyActiveProjects ||
+      followScreenEnabled
     )
   }, [
     selectedCountries,
@@ -196,6 +198,7 @@ export const FilterProjectsProvider = ({ children }) => {
     showYourData,
     methodDataSharingFilters,
     projectNameFilter,
+    enableFollowScreen,
   ])
 
   const applyFilterToProjects = useCallback(
@@ -620,6 +623,7 @@ export const FilterProjectsProvider = ({ children }) => {
     setMethodDataSharingFilters([])
     setProjectNameFilter('')
     setShowYourData(false)
+    setEnableFollowScreen(false)
     updateURLParams(queryParams)
   }
 

--- a/src/context/FilterProjectsContext.jsx
+++ b/src/context/FilterProjectsContext.jsx
@@ -128,6 +128,12 @@ export const FilterProjectsProvider = ({ children }) => {
       }
     }
 
+    const setFollowScreen = () => {
+      if (queryParams.has(URL_PARAMS.FOLLOW_SCREEN)) {
+        setEnableFollowScreen(true)
+      }
+    }
+
     setFilterValue(URL_PARAMS.COUNTRIES, 'country', setSelectedCountries)
     setFilterValue(URL_PARAMS.ORGANIZATIONS, 'organization', setSelectedOrganizations)
     handleDateFilter(URL_PARAMS.SAMPLE_DATE_AFTER, setSampleDateAfter, (date) =>
@@ -136,6 +142,7 @@ export const FilterProjectsProvider = ({ children }) => {
     handleDateFilter(URL_PARAMS.SAMPLE_DATE_BEFORE, setSampleDateBefore, formatEndDate)
     handleMethodDataSharingFilter()
     setProjectNameValue()
+    setFollowScreen()
   }, [getURLParams, updateURLParams])
 
   const doesSelectedSampleEventPassFilters = useCallback(
@@ -397,7 +404,9 @@ export const FilterProjectsProvider = ({ children }) => {
       : applyFilterToProjects(selectedCountries, selectedOrganizations)
     const paramsSampleEventId =
       queryParams.has('sample_event_id') && queryParams.get('sample_event_id')
-    doesSelectedSampleEventPassFilters(paramsSampleEventId, filteredProjects)
+    if (projectData.results.length === projectData.count) {
+      doesSelectedSampleEventPassFilters(paramsSampleEventId, filteredProjects)
+    }
 
     setDisplayedProjects(
       filteredProjects.sort((a, b) => a.project_name.localeCompare(b.project_name)),


### PR DESCRIPTION
https://trello.com/c/HAs8VhkD/871-follow-my-screen-option

- Add button for user to follow the screen, which will update the metrics pane based on what's currently on the screen
- If a user has filters applied, this follow screen feature further filters that subset of data
- Clearing the filters will also clear the follow screen function
- Store state of follow screen in the url params
- Switching to table view, hiding the metrics pane, or selecting a site will hide the checkbox. The state of follow screen is still preserved