### PR TITLE
1052 misc ux bugs

### DIFF
--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -231,12 +231,15 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
         setView={setView}
         projectDataCount={projectData?.count || 0}
       />
-      <LoadingIndicator
-        currentProgress={projectData?.results?.length || 0}
-        finalProgress={projectData?.count || 0}
-        showLoadingIndicator={showLoadingIndicator}
-        setShowLoadingIndicator={setShowLoadingIndicator}
-      />
+      {isMobileWidth ? null : (
+        <LoadingIndicator
+          currentProgress={projectData?.results?.length || 0}
+          finalProgress={projectData?.count || 0}
+          showLoadingIndicator={showLoadingIndicator}
+          setShowLoadingIndicator={setShowLoadingIndicator}
+          isRelativelyPositioned={false}
+        />
+      )}
     </StyledMapContainer>
   )
 
@@ -266,6 +269,7 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
           setShowMetricsPane={setShowMetricsPane}
           view={view}
           showLoadingIndicator={showLoadingIndicator}
+          setShowLoadingIndicator={setShowLoadingIndicator}
         />
       </StyledContentContainer>
     </StyledDashboardContainer>

--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -252,15 +252,6 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
     </StyledTableContainer>
   )
 
-  const renderMetrics = () => (
-    <MetricsPane
-      showMetricsPane={showMetricsPane}
-      setShowMetricsPane={setShowMetricsPane}
-      view={view}
-      showLoadingIndicator={showLoadingIndicator}
-    />
-  )
-
   return (
     <StyledDashboardContainer>
       <Header />
@@ -270,7 +261,12 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
       <StyledContentContainer>
         {renderFilter(showFilterModal)}
         {isMobileWidth || view === 'mapView' ? map : table}
-        {renderMetrics()}
+        <MetricsPane
+          showMetricsPane={showMetricsPane}
+          setShowMetricsPane={setShowMetricsPane}
+          view={view}
+          showLoadingIndicator={showLoadingIndicator}
+        />
       </StyledContentContainer>
     </StyledDashboardContainer>
   )

--- a/src/components/MermaidDash/components/LoadingIndicator.jsx
+++ b/src/components/MermaidDash/components/LoadingIndicator.jsx
@@ -5,7 +5,10 @@ import theme from '../../../styles/theme'
 import { mediaQueryTabletLandscapeOnly } from '../../../styles/mediaQueries'
 
 const StyledLoadingContainer = styled.div`
-  position: absolute;
+  position: ${(props) =>
+    props.$isRelativelyPositioned
+      ? 'relative'
+      : 'absolute'}; // if the loader is in the metric pane, it needs relative positioning, otherwise in the map pane, it needs absolute.
   width: '20rem';
   bottom: 1.5rem;
   left: 1.5rem;
@@ -16,7 +19,7 @@ const StyledLoadingContainer = styled.div`
     left: auto;
     display: flex;
     flex-direction: row;
-    width: calc(100% - 2rem);
+    width: calc(100% - 2rem); // leave room for 'padding'
     justify-content: center;
     background-color: ${theme.color.white};
     justify-self: center;
@@ -54,6 +57,7 @@ const LoadingIndicator = ({
   finalProgress,
   showLoadingIndicator,
   setShowLoadingIndicator,
+  isRelativelyPositioned = false,
 }) => {
   const [loadingProgressValue, setLoadingProgressValue] = useState(0)
 
@@ -73,7 +77,7 @@ const LoadingIndicator = ({
   }, [loadingProgressValue, setShowLoadingIndicator])
 
   return showLoadingIndicator === true ? (
-    <StyledLoadingContainer>
+    <StyledLoadingContainer $isRelativelyPositioned={isRelativelyPositioned}>
       <StyledHeader>
         {loadingProgressValue === 100
           ? `Done ${loadingProgressValue}%`
@@ -89,8 +93,9 @@ const LoadingIndicator = ({
 LoadingIndicator.propTypes = {
   currentProgress: PropTypes.number.isRequired,
   finalProgress: PropTypes.number.isRequired,
-  showLoadingIndicator: PropTypes.bool.isRequired,
+  isRelativelyPositioned: PropTypes.bool,
   setShowLoadingIndicator: PropTypes.func.isRequired,
+  showLoadingIndicator: PropTypes.bool.isRequired,
 }
 
 export default LoadingIndicator

--- a/src/components/MermaidDash/components/LoadingIndicator.jsx
+++ b/src/components/MermaidDash/components/LoadingIndicator.jsx
@@ -16,7 +16,7 @@ const StyledLoadingContainer = styled.div`
     left: auto;
     display: flex;
     flex-direction: row;
-    width: 90vw;
+    width: calc(100% - 2rem);
     justify-content: center;
     background-color: ${theme.color.white};
     justify-self: center;

--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -49,8 +49,15 @@ import ZoomToSiteIcon from '../../assets/zoom_to_selected_sites.svg?react'
 import { getIsSiteSelected, zoomToSelectedSite } from '../../helperFunctions/selectedSite'
 import { useMap } from 'react-map-gl'
 import { MAIN_MAP_ID } from '../../constants/constants'
+import LoadingIndicator from '../MermaidDash/components/LoadingIndicator'
 
-const MetricsPane = ({ showMetricsPane, setShowMetricsPane, view, showLoadingIndicator }) => {
+const MetricsPane = ({
+  setShowLoadingIndicator,
+  setShowMetricsPane,
+  showLoadingIndicator,
+  showMetricsPane,
+  view,
+}) => {
   const [numSurveys, setNumSurveys] = useState(0)
   const [numTransects, setNumTransects] = useState(0)
   const [numUniqueCountries, setNumUniqueCountries] = useState(0)
@@ -63,6 +70,7 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, view, showLoadingInd
     getActiveProjectCount,
     getURLParams,
     mermaidUserData,
+    projectData,
     selectedMarkerId,
     setEnableFollowScreen,
     setSelectedMarkerId,
@@ -423,6 +431,15 @@ const MetricsPane = ({ showMetricsPane, setShowMetricsPane, view, showLoadingInd
           {showMobileExpandedMetricsPane ? <BiggerIconCaretDown /> : <BiggerIconCaretUp />}
         </MobileExpandMetricsPaneButton>
       )}
+      {isMobileWidth ? (
+        <LoadingIndicator
+          currentProgress={projectData?.results?.length || 0}
+          finalProgress={projectData?.count || 0}
+          showLoadingIndicator={showLoadingIndicator}
+          setShowLoadingIndicator={setShowLoadingIndicator}
+          isRelativelyPositioned={true}
+        />
+      ) : null}
     </StyledMetricsWrapper>
   )
 }
@@ -432,6 +449,7 @@ MetricsPane.propTypes = {
   setShowMetricsPane: PropTypes.func.isRequired,
   view: PropTypes.oneOf(['mapView', 'tableView']).isRequired,
   showLoadingIndicator: PropTypes.bool.isRequired,
+  setShowLoadingIndicator: PropTypes.func.isRequired,
 }
 
 export default MetricsPane

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -29,11 +29,11 @@ export const StyledMetricsWrapper = styled.div`
     width: 100%;
     bottom: 0.5rem;
     display: grid;
-    transform: ${(props) => (props.$showLoadingIndicator ? 'translateY(-3.2rem)' : 'none')}
-      ${(props) =>
-        props.$showMobileExpandedMetricsPane &&
-        `
-      top: 7.9rem;
+    transform: ${(props) => (props.$showLoadingIndicator ? 'translateY(-3.2rem)' : 'none')};
+    ${(props) =>
+      props.$showMobileExpandedMetricsPane &&
+      `
+     top: 9.8rem;
       width: 100vw;
       bottom: 0;
     `};

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -105,6 +105,7 @@ export const MobileExpandMetricsPaneButton = styled(ButtonSecondary)`
   `)}
 
   ${mediaQueryTabletLandscapeOnly(css`
+    width: 100%;
     font-size: ${theme.typography.largeIconSize};
     display: block;
     position: absolute;
@@ -114,7 +115,6 @@ export const MobileExpandMetricsPaneButton = styled(ButtonSecondary)`
     border: none;
     color: ${theme.color.white};
     ${(props) => props.$showMobileExpandedMetricsPane && `background-color: ${theme.color.grey1};`}
-    ${(props) => props.$showMobileExpandedMetricsPane && 'width: 100vw;'}
     -webkit-text-stroke-width: 1px;
     -webkit-text-stroke-color: black;
   `)}
@@ -202,7 +202,7 @@ export const InlineOnDesktopMetricWrapper = styled.div`
 export const MobileExpandedMetricsPane = styled.div`
   background-color: ${theme.color.grey1};
   height: calc(100vh - 24rem);
-  width: 100vw;
+  width: 100%;
 `
 
 export const SelectedSiteMetricsCardContainer = styled.div`

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -27,9 +27,9 @@ export const StyledMetricsWrapper = styled.div`
   ${mediaQueryTabletLandscapeOnly(css`
     position: absolute;
     width: 100%;
-    bottom: 0.5rem;
+    bottom: 0;
     display: grid;
-    transform: ${(props) => (props.$showLoadingIndicator ? 'translateY(-3.2rem)' : 'none')};
+    grid-template-rows: auto 1fr;
     ${(props) =>
       props.$showMobileExpandedMetricsPane &&
       `
@@ -201,7 +201,6 @@ export const InlineOnDesktopMetricWrapper = styled.div`
 `
 export const MobileExpandedMetricsPane = styled.div`
   background-color: ${theme.color.grey1};
-  height: calc(100vh - 24rem);
   width: 100%;
 `
 


### PR DESCRIPTION
work performed: 
- make mobile loader full width
- ensure loader shows when mobile metric pane is expanded
- make room for future charts and other metric pane content (dynamic container height required)
- remove extra horizontal scroll from metric pane
- make expanded mobile metric pane take up full height as shown in figma.

<img width="814" alt="Screenshot 2024-09-24 at 11 50 19 AM" src="https://github.com/user-attachments/assets/4cdf8599-96d7-4ce8-a8a0-788233adf7a8">
<img width="814" alt="Screenshot 2024-09-24 at 11 50 15 AM" src="https://github.com/user-attachments/assets/5fa25a62-82e7-48dd-91e6-bedabb8a2910">
<img width="1380" alt="Screenshot 2024-09-24 at 11 49 55 AM" src="https://github.com/user-attachments/assets/45063ae6-0111-401d-957a-04ed5b5dfbf8">

