### PR TITLE
1055 hide map zoom control on mobile

### DIFF
--- a/src/components/MaplibreMap.jsx
+++ b/src/components/MaplibreMap.jsx
@@ -335,11 +335,8 @@ const MaplibreMap = ({ view, setView }) => {
           customAttribution="Source: Esri, Maxar, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AeroGRID, IGN, and the GIS User Community"
           position={isDesktopWidth ? 'bottom-right' : 'top-right'}
         />
-        <NavigationControl
-          showCompass={false}
-          showZoom={isDesktopWidth ? true : false}
-          position="bottom-right"
-        />
+        {isDesktopWidth ? <NavigationControl showCompass={false} position="bottom-right" /> : null}
+
         <Source
           id="basemap-source"
           type="raster"


### PR DESCRIPTION
@saanobhaai found that the zoom control was still showing on the mobile map, but with stuff overlapping it. I noticed the code is is intending to hide it using a React Map GL showZoom pop that might not be working consistently, so I opted to use a conditional react expression to not render the zoom control unless we are in desktop view 