### PR TITLE
815 single selected site 3 survey date select

### DIFF
--- a/src/components/FilterPane/FilterPane.jsx
+++ b/src/components/FilterPane/FilterPane.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
-import { Select, Box, IconButton } from '@mui/material'
+import { Box, IconButton } from '@mui/material'
+
 import {
   StyledHeader,
   StyledFormContainer,
@@ -16,7 +17,6 @@ import {
   StyledMethodListContainer,
   StyledDateInputContainer,
   StyledDateInput,
-  StyledMenuItem,
   StyledListSubheader,
   StyledClickableArea,
   StyledLabel,
@@ -28,36 +28,18 @@ import {
   TieredStyledClickableArea,
 } from './FilterPane.styles'
 import { filterPane } from '../../constants/language'
-import { URL_PARAMS, COLLECTION_METHODS } from '../../constants/constants'
-import { useEffect, useState, useCallback, useContext } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { FilterProjectsContext } from '../../context/FilterProjectsContext'
 import { IconClose, IconPlus } from '../../assets/icons'
 import { IconUserCircle, IconMinus } from '../../assets/dashboardOnlyIcons'
-import { FilterProjectsContext } from '../../context/FilterProjectsContext'
+import { MermaidMenuItem, MermaidSelect } from '../generic/MermaidSelect'
+import { URL_PARAMS, COLLECTION_METHODS } from '../../constants/constants'
 import { useAuth0 } from '@auth0/auth0-react'
+import { useEffect, useState, useCallback, useContext } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 
 const deleteIconSize = {
   height: '15px',
   width: '15px',
-}
-
-const selectCustomStyles = {
-  '&.MuiInputBase-root': {
-    minHeight: '3.5rem',
-  },
-  '& .MuiSelect-select': {
-    paddingRight: '1rem',
-    paddingLeft: '1rem',
-    paddingTop: '0.5rem',
-    paddingBottom: '0.5rem',
-  },
-  MenuProps: {
-    PaperProps: {
-      sx: {
-        maxHeight: '50vh',
-      },
-    },
-  },
 }
 
 const selectBoxCustomStyles = { display: 'flex', flexWrap: 'wrap', gap: 0.5 }
@@ -315,13 +297,11 @@ const FilterPane = ({ mermaidUserData }) => {
       <StyledHeader>Countries</StyledHeader>
       <StyledFormContainer>
         <StyledFormControl>
-          <Select
+          <MermaidSelect
             multiple
             value={selectedCountries}
             onChange={handleSelectedCountriesChange}
             input={<StyledOutlinedInput />}
-            sx={selectCustomStyles}
-            MenuProps={selectCustomStyles.MenuProps}
             onOpen={countriesSelectOnOpen}
             renderValue={(selected) => (
               <Box sx={selectBoxCustomStyles}>
@@ -345,33 +325,31 @@ const FilterPane = ({ mermaidUserData }) => {
               <StyledListSubheader>Countries based on current filters</StyledListSubheader>
             ) : null}
             {displayedCountries.map((country) => (
-              <StyledMenuItem key={`matches-${country}`} value={country}>
+              <MermaidMenuItem key={`matches-${country}`} value={country}>
                 <input type="checkbox" checked={selectedCountries.includes(country)} readOnly />
                 {country}
-              </StyledMenuItem>
+              </MermaidMenuItem>
             ))}
             {remainingDisplayedCountries.length ? (
               <StyledListSubheader>Other countries</StyledListSubheader>
             ) : null}
             {remainingDisplayedCountries.map((country) => (
-              <StyledMenuItem key={`nonmatches-${country}`} value={country}>
+              <MermaidMenuItem key={`nonmatches-${country}`} value={country}>
                 <input type="checkbox" checked={selectedCountries.includes(country)} readOnly />
                 {country}
-              </StyledMenuItem>
+              </MermaidMenuItem>
             ))}
-          </Select>
+          </MermaidSelect>
         </StyledFormControl>
       </StyledFormContainer>
       <StyledHeader>Organizations</StyledHeader>
       <StyledFormContainer>
         <StyledFormControl>
-          <Select
+          <MermaidSelect
             multiple
             value={selectedOrganizations}
             onChange={handleSelectedOrganizationsChange}
             input={<StyledOutlinedInput />}
-            sx={selectCustomStyles}
-            MenuProps={selectCustomStyles.MenuProps}
             onOpen={organizationsSelectOnOpen}
             renderValue={(selected) => (
               <Box sx={selectBoxCustomStyles}>
@@ -397,16 +375,16 @@ const FilterPane = ({ mermaidUserData }) => {
                 : 'No organizations match current filters'}
             </StyledListSubheader>
             {displayedOrganizations.map((organization) => (
-              <StyledMenuItem key={organization} value={organization}>
+              <MermaidMenuItem key={organization} value={organization}>
                 <input
                   type="checkbox"
                   checked={selectedOrganizations.includes(organization)}
                   readOnly
                 />
                 {organization}
-              </StyledMenuItem>
+              </MermaidMenuItem>
             ))}
-          </Select>
+          </MermaidSelect>
         </StyledFormControl>
       </StyledFormContainer>
       <StyledExpandFilters onClick={() => setShowMoreFilters(!showMoreFilters)}>

--- a/src/components/FilterPane/FilterPane.styles.js
+++ b/src/components/FilterPane/FilterPane.styles.js
@@ -1,4 +1,4 @@
-import { FormControl, MenuItem, OutlinedInput, Chip, TextField, ListSubheader } from '@mui/material'
+import { FormControl, OutlinedInput, Chip, TextField, ListSubheader } from '@mui/material'
 import styled from 'styled-components'
 import theme from '../../styles/theme'
 import { hoverState, mediaQueryTabletLandscapeOnly } from '../../styles/mediaQueries'
@@ -127,12 +127,6 @@ export const StyledDateInput = styled.div`
     background: none;
     border: none;
     cursor: pointer;
-  }
-`
-
-export const StyledMenuItem = styled(MenuItem)`
-  &.MuiMenuItem-root {
-    font-size: ${theme.typography.defaultFontSize};
   }
 `
 

--- a/src/components/MaplibreMap.jsx
+++ b/src/components/MaplibreMap.jsx
@@ -103,7 +103,7 @@ const MaplibreMap = ({ view, setView }) => {
     enableFollowScreen,
     selectedMarkerId,
     setMapBbox,
-    setSelectedMarkerId,
+    updateCurrentSampleEvent,
   } = useContext(FilterProjectsContext)
   const prevDisplayedProjects = usePrevious(displayedProjects)
   const location = useLocation()
@@ -236,10 +236,7 @@ const MaplibreMap = ({ view, setView }) => {
 
       if (clickedFeature.layer.id === 'sites-unclustered-layer') {
         const { sample_event_id } = clickedFeature.properties
-        const newQueryParams = getURLParamsSnapshot()
-        newQueryParams.set('sample_event_id', sample_event_id)
-        updateURLParams(newQueryParams)
-        setSelectedMarkerId(sample_event_id)
+        updateCurrentSampleEvent(sample_event_id)
 
         return
       }

--- a/src/components/generic/MermaidSelect.jsx
+++ b/src/components/generic/MermaidSelect.jsx
@@ -1,0 +1,32 @@
+import { MenuItem, Select } from '@mui/material'
+import styled from 'styled-components'
+import theme from '../../styles/theme'
+
+const selectCustomStyles = {
+  '&.MuiInputBase-root': {
+    minHeight: '3.5rem',
+  },
+  '& .MuiSelect-select': {
+    paddingRight: '1rem',
+    paddingLeft: '1rem',
+    paddingTop: '0.5rem',
+    paddingBottom: '0.5rem',
+  },
+  MenuProps: {
+    PaperProps: {
+      sx: {
+        maxHeight: '50vh',
+      },
+    },
+  },
+}
+
+export const MermaidMenuItem = styled(MenuItem)`
+  &.MuiMenuItem-root {
+    font-size: ${theme.typography.defaultFontSize};
+  }
+`
+
+export const MermaidSelect = (props) => {
+  return <Select sx={selectCustomStyles} MenuProps={selectCustomStyles.MenuProps} {...props} />
+}

--- a/src/context/FilterProjectsContext.jsx
+++ b/src/context/FilterProjectsContext.jsx
@@ -573,6 +573,16 @@ export const FilterProjectsProvider = ({ children }) => {
     return count
   }
 
+  const updateCurrentSampleEvent = useCallback(
+    (sampleEventId) => {
+      const newQueryParams = new URLSearchParams(location.search)
+      newQueryParams.set('sample_event_id', sampleEventId)
+      updateURLParams(newQueryParams)
+      setSelectedMarkerId(sampleEventId)
+    },
+    [location.search, updateURLParams],
+  )
+
   return (
     <FilterProjectsContext.Provider
       value={{
@@ -621,6 +631,7 @@ export const FilterProjectsProvider = ({ children }) => {
         setShowYourData,
         showProjectsWithNoRecords,
         showYourData,
+        updateCurrentSampleEvent,
         updateURLParams,
         userIsMemberOfProject,
       }}


### PR DESCRIPTION
[Ticket](https://trello.com/c/dh9PuTaD/815-single-site-metric-pane?filter=label:dash%20app)


If a site has more than one survey, show a dropdown for the dates of all the available surveys. When the user selects a different survey by date, the url updates the `sample_event_id` parameter and the new sample event is shown (currently its hard to distinguish that a new sample event is showing since metadata appears the same across same-site sample events, at least in the data I tested 

This url will bring you to a site with multiple surveys to choose from. 

http://localhost:3030/?lat=16.78071160736721&lng=-87.78895854949951&zoom=17&sample_event_id=b05c6fb8-09fe-4419-8d51-541426e91804
<img width="362" alt="Screenshot 2024-09-26 at 12 56 13 PM" src="https://github.com/user-attachments/assets/50fbc6a8-a761-4b11-869e-c68b0a7496bf">
<img width="362" alt="Screenshot 2024-09-26 at 12 56 00 PM" src="https://github.com/user-attachments/assets/e3338da1-ade5-43fb-9b70-41b49c1fadd7">


