### PR TITLE
M1067: Consistent Padding for Metrics Pane

### DIFF
--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -7,8 +7,8 @@ import { IconCaretUp, IconCaretDown } from '../../assets/dashboardOnlyIcons'
 export const StyledMetricsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
+  gap: 0.5rem;
+  padding: 0.5rem;
   ${(props) => props.$showMetricsPane && 'min-width: 35rem;'}
   ${(props) => !props.$showMetricsPane && 'max-width: 40rem;'}
   position: relative;

--- a/src/components/MetricsPane/SelectedSiteMetrics.styles.js
+++ b/src/components/MetricsPane/SelectedSiteMetrics.styles.js
@@ -123,6 +123,7 @@ export const TabContent = styled.div`
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: ${theme.color.grey0} ${theme.color.grey1};
-  margin-right: -1rem; // make scrollbar not take up too much space
   scrollbar-gutter: stable; // if no scrollbar, make sure the 'padded look from the parent is preserved
+  // Commented-out as it was causing unalignment in the pane. Not deleting if I learn it is needed in future.
+  /* margin-right: -1rem; // make scrollbar not take up too much space */
 `


### PR DESCRIPTION
Relates to [Ticket 1067
](https://trello.com/c/V9aEscdo/1067-use-consistent-padding-and-gap-in-metrics-pane)

**Changes:**
- Reduced padding and gap to match rest of metrics pane.
- Commented-out negative margin.

**Screenshot:**
<img width="1512" alt="Screenshot 2024-10-09 at 2 53 09 PM" src="https://github.com/user-attachments/assets/3552e314-88d8-478e-aa0d-7379314ae770">
