### PR TITLE
M1048: Bug Project Title spilling outside card

### DIFF
--- a/src/components/MetricsPane/SelectedSiteMetrics.styles.js
+++ b/src/components/MetricsPane/SelectedSiteMetrics.styles.js
@@ -22,6 +22,10 @@ export const SelectedSiteContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 27.5rem;
+
+  & span {
+    overflow-wrap: break-word;
+  }
 `
 
 export const SelectedSiteContentContainerWiderOnMobile = styled(SelectedSiteContentContainer)`


### PR DESCRIPTION
Relates to [Ticket 1048](https://trello.com/c/LrTeyXYy/1048-metrics-pane-project-card-text-spills-outside-of-card)

**Changes**
- Added `overflow-wrap: break-word` to `span` inside `SelectedSiteContentContainer`

**To Test**
- Open a project with a long name without spaces, ensure it doesn't overflow
  - Alternatively, open dev tools, edit name of project in `span` to something like `asdfasdfasdfasdfasdfasdfasdfsdfasdfasdfsdfsadfs`

**Screenshot**
<img width="1512" alt="Screenshot 2024-10-09 at 3 18 01 PM" src="https://github.com/user-attachments/assets/55dc383a-ef3b-4fbd-b9f6-648742946511">
