### PR TITLE
1011 make existing charts work with Mobile view

### DIFF
--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -17,6 +17,8 @@ import {
   MetricCardPBig,
   MetricCardPMedium,
   InlineOnDesktopMetricWrapper,
+  DisplayedProjectsMetricsWrapper,
+  ChartsWrapper,
 } from './MetricsPane.styles'
 import { FilterProjectsContext } from '../../context/FilterProjectsContext'
 import LoadingIndicator from '../MermaidDash/components/LoadingIndicator'
@@ -152,57 +154,62 @@ const MetricsPane = ({
   )
 
   const displayedProjectsMetrics = (
-    <SummarizedMetrics
-      onClick={toggleMobileMetricsPane}
-      $isDesktopWidth={isDesktopWidth}
-      $showMobileExpandedMetricsPane={showMobileExpandedMetricsPane}
-      $showLoadingIndicator={showLoadingIndicator}
-    >
-      <MetricsCard>
-        <MetricCardPBig>{numSurveys.toLocaleString()}</MetricCardPBig>
-        <MetricCardH3>Surveys</MetricCardH3>
-      </MetricsCard>
-      <MetricsCard>
+    <DisplayedProjectsMetricsWrapper>
+      <SummarizedMetrics
+        onClick={toggleMobileMetricsPane}
+        $isDesktopWidth={isDesktopWidth}
+        $showMobileExpandedMetricsPane={showMobileExpandedMetricsPane}
+        $showLoadingIndicator={showLoadingIndicator}
+      >
+        <MetricsCard>
+          <MetricCardPBig>{numSurveys.toLocaleString()}</MetricCardPBig>
+          <MetricCardH3>Surveys</MetricCardH3>
+        </MetricsCard>
+        <MetricsCard>
+          {isDesktopWidth ? (
+            <InlineOnDesktopMetricWrapper>
+              <span>{numUniqueCountries.toLocaleString()}</span>{' '}
+              <MetricCardH3>{countryLabel}</MetricCardH3>
+            </InlineOnDesktopMetricWrapper>
+          ) : (
+            <>
+              <MetricCardPBig>{numUniqueCountries.toLocaleString()}</MetricCardPBig>
+              <MetricCardH3>{countryLabel}</MetricCardH3>
+            </>
+          )}
+        </MetricsCard>
         {isDesktopWidth ? (
-          <InlineOnDesktopMetricWrapper>
-            <span>{numUniqueCountries.toLocaleString()}</span>{' '}
-            <MetricCardH3>{countryLabel}</MetricCardH3>
-          </InlineOnDesktopMetricWrapper>
+          <MultipleMetricCardsRow>{transectAndProjectCountCards}</MultipleMetricCardsRow>
         ) : (
-          <>
-            <MetricCardPBig>{numUniqueCountries.toLocaleString()}</MetricCardPBig>
-            <MetricCardH3>{countryLabel}</MetricCardH3>
-          </>
+          transectAndProjectCountCards
         )}
-      </MetricsCard>
-      {isDesktopWidth ? (
-        <MultipleMetricCardsRow>{transectAndProjectCountCards}</MultipleMetricCardsRow>
-      ) : (
-        transectAndProjectCountCards
-      )}
 
-      {isDesktopWidth ? <MetricsCard>{calculateMetrics.yearRange}</MetricsCard> : null}
-      <MetricsPaneChartTabs
-        id="hard-coral-cover"
-        aggregatePanelContent={<AggregateHardCoralCover />}
-        timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
-      />
-      <MetricsPaneChartTabs
-        id="fish-biomass"
-        aggregatePanelContent={<AggregateFishBiomass />}
-        timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
-      />
-      <MetricsPaneChartTabs
-        id="Bleaching"
-        aggregatePanelContent={<AggregateBleaching />}
-        timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
-      />
-      <MetricsPaneChartTabs
-        id="habitat-complexity"
-        aggregatePanelContent={<AggregateHabitatComplexity />}
-        timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
-      />
-    </SummarizedMetrics>
+        {isDesktopWidth ? <MetricsCard>{calculateMetrics.yearRange}</MetricsCard> : null}
+      </SummarizedMetrics>
+      <ChartsWrapper $showMobileExpandedMetricsPane={showMobileExpandedMetricsPane}>
+        <MetricsPaneChartTabs
+          id="hard-coral-cover"
+          aggregatePanelContent={<AggregateHardCoralCover />}
+          timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
+        />
+        <MetricsPaneChartTabs
+          id="fish-biomass"
+          aggregatePanelContent={<AggregateFishBiomass />}
+          timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
+        />
+
+        <MetricsPaneChartTabs
+          id="Bleaching"
+          aggregatePanelContent={<AggregateBleaching />}
+          timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
+        />
+        <MetricsPaneChartTabs
+          id="habitat-complexity"
+          aggregatePanelContent={<AggregateHabitatComplexity />}
+          timeSeriesPanelContent={<div style={{ height: '270px' }}>Coming soon</div>}
+        />
+      </ChartsWrapper>
+    </DisplayedProjectsMetricsWrapper>
   )
 
   const metricsContent =

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -40,16 +40,29 @@ export const StyledMetricsWrapper = styled.div`
       `};
   `)}
 `
+export const DisplayedProjectsMetricsWrapper = styled.div`
+  overflow-y: scroll;
+  height: 100%;
+`
+export const ChartsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
 
+  ${mediaQueryTabletLandscapeOnly(css`
+    display: ${(props) => (props.$showMobileExpandedMetricsPane ? 'flex' : 'none')};
+  `)}
+`
 export const SummarizedMetrics = styled.div`
   width: 100%;
   overflow-y: scroll;
-  ${(props) => props.$isDesktopWidth && 'height: calc(100vh - 10rem);'}
   z-index: 2;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  margin-bottom: 0.5rem;
 
   /* Hide scrollbar */
   &::-webkit-scrollbar {
@@ -65,6 +78,7 @@ export const SummarizedMetrics = styled.div`
     justify-content: space-between;
     gap: 0.5rem;
     margin: 0;
+    margin-bottom: 0.5rem;
   `)}
 `
 

--- a/src/styles/dashboardOnlyTheme.js
+++ b/src/styles/dashboardOnlyTheme.js
@@ -46,6 +46,7 @@ const plotlyChart = {
       'resetScale2d',
     ],
     displaylogo: false,
+    responsive: true,
   },
 }
 const dashboardOnlyTheme = { color, plotlyChart }


### PR DESCRIPTION
⚠️ ⚠️ ⚠️ NOTE TO SELF: CHANGE BASE BRANCH TO DEVELOP BEFORE MERGE ⚠️ ⚠️ ⚠️

[Trello card](https://trello.com/c/Cnt8XPkw/1011-dashboard-visualizations-aggregate-translate-plotly-code-into-javascript-for-aggregate-plots-see-attached-file?filter=member:mnunes24)

Steps to test:
- clone `https://github.com/data-mermaid/mermaid-dash-v2`
- follow readme to get server running (api is prod, so dont need local back end)
- I updated the MERMAID secure note in dashlane. You will find env vars for this app at bottom of it
- load the app in the browser
- view the 4 new charts in desktop view
- shrink the screen to mobile size, the metrics pane is collapsed at the bottom of the screen
- expand the metrics pane to view the charts in mobile view

<img width="492" alt="Screenshot 2024-12-18 at 1 19 03 PM" src="https://github.com/user-attachments/assets/def151f3-2a2b-40cc-8957-e3bb0366e786" />
<img width="454" alt="Screenshot 2024-12-18 at 1 09 49 PM" src="https://github.com/user-attachments/assets/8e804428-9ec5-4cb7-9f4d-23a90059392f" />

