### PR TITLE
1153 make update metrics based on map view button visible

### DIFF
--- a/src/components/MetricsPane/MetricsPane.jsx
+++ b/src/components/MetricsPane/MetricsPane.jsx
@@ -19,6 +19,7 @@ import {
   InlineOnDesktopMetricWrapper,
   DisplayedProjectsMetricsWrapper,
   ChartsWrapper,
+  MetricsAndMetricsToggleButtonWrapper,
 } from './MetricsPane.styles'
 import { FilterProjectsContext } from '../../context/FilterProjectsContext'
 import LoadingIndicator from '../MermaidDash/components/LoadingIndicator'
@@ -245,7 +246,7 @@ const MetricsPane = ({
   }
 
   return (
-    <>
+    <MetricsAndMetricsToggleButtonWrapper>
       <StyledMetricsWrapper
         $showMetricsPane={showMetricsPane}
         $showMobileExpandedMetricsPane={showMobileExpandedMetricsPane}
@@ -301,7 +302,7 @@ const MetricsPane = ({
           <StyledChevronSpan>{showMetricsPane ? ARROW_RIGHT : ARROW_LEFT}</StyledChevronSpan>
         </DesktopToggleMetricsPaneButton>
       ) : null}
-    </>
+    </MetricsAndMetricsToggleButtonWrapper>
   )
 }
 

--- a/src/components/MetricsPane/MetricsPane.styles.js
+++ b/src/components/MetricsPane/MetricsPane.styles.js
@@ -4,6 +4,10 @@ import theme from '../../styles/theme'
 import { ButtonSecondary } from '../generic'
 import { IconCaretUp, IconCaretDown } from '../../assets/dashboardOnlyIcons'
 
+export const MetricsAndMetricsToggleButtonWrapper = styled.div`
+  position: relative; // This is needed for the absolute positioning of children
+`
+
 export const StyledMetricsWrapper = styled.div`
   display: flex;
   flex-direction: column;
@@ -18,7 +22,6 @@ export const StyledMetricsWrapper = styled.div`
       : css`
           max-width: 40rem;
         `}
-  position: relative;
   z-index: 5;
   overflow-y: auto;
   background-color: ${(props) =>
@@ -96,7 +99,7 @@ export const BiggerIconCaretDown = styled(IconCaretDown)`
 
 export const DesktopToggleMetricsPaneButton = styled(ButtonSecondary)`
   position: absolute;
-  top: 6.2rem; // 1.3rem + header height (theme.spacing.headerHeight)
+  top: 1.3rem;
   right: ${({ $showMetricsPane }) => ($showMetricsPane ? '35rem' : 0)};
   height: 6rem;
   z-index: 5;


### PR DESCRIPTION
Description of work: make update metrics based on map view button visible

[Trello card](https://trello.com/c/qZ0f8IvS/1153-filter-by-map-extent-regression)

Steps to test:
Open the app, see the 'Update metrics based on map view' button.

<img width="1728" alt="Screenshot 2024-12-18 at 4 30 15 PM" src="https://github.com/user-attachments/assets/14fdcb1c-cc13-47cd-abd4-6caca59a1db9" />
