### PR TITLE
Configure dev server for easier mobile testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ This SPA is the second version of the Mermaid Dashboard.
 
 # Mobile Testing
 
+## Approach 1
+
+1. Run the dev server with the `--host` flag. `Yarn dev --host`.
+2. Open the site on your mobile device using the network address for the app printed in the dev server console. Make sure you are using https.
+3. Proceed past the warning about untrusted certificates to view the app
+
+## Approach 2
+
 1. Download Termius on your mobile (scroll down for download link for iOS) https://termius.com/download/android
 2. Open Termius on your phone. You don't need to create an account for the app to work
 3. Create a new host

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@rollup/plugin-babel": "^6.0.4",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
+    "@vitejs/plugin-basic-ssl": "^1.2.0",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "8.56.0",
     "eslint-plugin-react": "^7.34.1",

--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -37,7 +37,7 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
   const location = useLocation()
   const navigate = useNavigate()
   const { isMobileWidth, isDesktopWidth } = useResponsive()
-  const { isLoading, isAuthenticated, getAccessTokenSilently } = useAuth0()
+  const { isAuthenticated, getAccessTokenSilently } = useAuth0()
   const [showLoadingIndicator, setShowLoadingIndicator] = useState(!isApiDataLoaded)
 
   const getAuthorizationHeaders = async (getAccessTokenSilently) => ({
@@ -128,18 +128,8 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
       }
     }
 
-    if (isLoading) {
-      return
-    }
     handleFetchData()
-  }, [
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    fetchUserProfile,
-    fetchData,
-    setMermaidUserData,
-  ])
+  }, [isAuthenticated, getAccessTokenSilently, fetchUserProfile, fetchData, setMermaidUserData])
 
   const updateURLParams = useCallback(
     (queryParams) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import svgr from 'vite-plugin-svgr'
+import basicSsl from '@vitejs/plugin-basic-ssl'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,5 +10,6 @@ export default defineConfig({
       'top-level-await': true,
     },
   },
-  plugins: [react(), svgr()],
+  plugins: [react(), svgr(), basicSsl()],
+  server: { https: true },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,6 +2069,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitejs/plugin-basic-ssl@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@vitejs/plugin-basic-ssl@npm:1.2.0"
+  peerDependencies:
+    vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+  checksum: 10c0/0d360fcca01f91ade6e451edbea09a107ff9e95cd3c3766c7a069d1a168709df92d96c0bd1eccc66e2739a153e07c75a45321ec487450c0da942606200d8441d
+  languageName: node
+  linkType: hard
+
 "@vitejs/plugin-react@npm:^4.2.1":
   version: 4.2.1
   resolution: "@vitejs/plugin-react@npm:4.2.1"
@@ -6114,6 +6123,7 @@ __metadata:
     "@turf/helpers": "npm:^7.1.0"
     "@types/react": "npm:^18.2.66"
     "@types/react-dom": "npm:^18.2.22"
+    "@vitejs/plugin-basic-ssl": "npm:^1.2.0"
     "@vitejs/plugin-react": "npm:^4.2.1"
     babel-plugin-styled-components: "npm:^2.1.4"
     color: "npm:^4.2.3"


### PR DESCRIPTION
Instead of installing and configuring an app on every mobile device, this configuration enables us to test on any mobile device without alteration on the same network as the dev server is running.

Prerequisite to merge is to make the work with login is fixing an Auth0 callback url issue. If we're able to do this, this should be good to go for merging to develop. The app will work without this Auth0 config fix, but a 403 error will occur in the background and the login button wont work.

For now, this branch is to demo, discuss, and PR the configuration. A good place to start is to see the readme diff.

@saanobhaai @alanjleonard 