### PR TITLE
[M1180] Don't allow users to select a date in the future.

### DIFF
--- a/src/components/FilterPane/FilterPane.jsx
+++ b/src/components/FilterPane/FilterPane.jsx
@@ -42,6 +42,7 @@ import AutocompleteCheckbox from '../generic/AutocompleteCheckbox'
 const DATA_SHARING_LABELS = ['Public', 'Public Summary', 'Private']
 
 const FilterPane = ({ mermaidUserData }) => {
+  const todayDate = dayjs()
   const [showMoreFilters, setShowMoreFilters] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
@@ -356,7 +357,7 @@ const FilterPane = ({ mermaidUserData }) => {
                 value={sampleDateAfter}
                 onChange={(date) => handleStartDateChange(date)}
                 format="YYYY-MM-DD"
-                maxDate={dayjs(sampleDateBefore)}
+                maxDate={sampleDateBefore ? dayjs(sampleDateBefore) : todayDate}
                 slots={{ textField: StyledDateField }}
                 slotProps={{
                   textField: { clearable: true, size: 'small' },
@@ -374,6 +375,7 @@ const FilterPane = ({ mermaidUserData }) => {
                 onChange={(date) => handleEndDateChange(date)}
                 format="YYYY-MM-DD"
                 minDate={sampleDateAfter ? dayjs(sampleDateAfter) : undefined}
+                maxDate={todayDate}
                 slots={{ textField: StyledDateField }}
                 slotProps={{
                   textField: { clearable: true, size: 'small' },


### PR DESCRIPTION
trello: https://trello.com/c/YmELg8R3/1180-dont-allow-users-to-select-a-date-in-the-future

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced date picker functionality with improved date range validation
	- Added current date limit to date selection to prevent future date selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->