### PR TITLE
[M1174] Remove label for Orgs based on current filters when there are no filters applied.

### DIFF
--- a/src/components/FilterPane/FilterPane.jsx
+++ b/src/components/FilterPane/FilterPane.jsx
@@ -175,9 +175,7 @@ const FilterPane = ({ mermaidUserData }) => {
   }
 
   const getOrganizationsAutocompleteGroup = () => {
-    return displayedOrganizations.length
-      ? autocompleteGroupNames.organizationsBasedOnCurrentFilters
-      : autocompleteGroupNames.noOrganizationsMatchCurrentFilters
+    return !!isAnyActiveFilters() ? autocompleteGroupNames.organizationsBasedOnCurrentFilters : ''
   }
 
   const handleShowProjectsWithNoRecords = () => {

--- a/src/components/generic/AutocompleteCheckbox.jsx
+++ b/src/components/generic/AutocompleteCheckbox.jsx
@@ -31,21 +31,48 @@ const AutocompleteCheckbox = ({
   onChange,
   onDelete,
 }) => {
+  const options = [...displayOptions, ...remainingOptions]
+
   return (
     <Autocomplete
       multiple
-      options={[...displayOptions, ...remainingOptions]}
+      options={options}
       value={selectedValues}
       onChange={(e, newValue) => onChange(newValue)}
       onOpen={onOpen}
       groupBy={autocompleteGroupBy}
       disableCloseOnSelect
       getOptionLabel={(option) => option}
-      filterOptions={(options, { inputValue }) =>
-        matchSorter(options, inputValue, {
-          keys: [(item) => item],
-        })
-      }
+      filterOptions={(options, { inputValue }) => {
+        // Group options by category
+        const groupedOptions = options.reduce((acc, option) => {
+          const group = autocompleteGroupBy(option)
+          if (!acc[group]) {
+            acc[group] = []
+          }
+
+          acc[group].push(option)
+
+          return acc
+        }, {})
+
+        // Apply matchSorter filtering within each group
+        const filteredGroups = Object.entries(groupedOptions).reduce((acc, [group, items]) => {
+          const filteredItems = matchSorter(items, inputValue, {
+            keys: [(item) => item],
+          })
+
+          console.log('filteredItems ', filteredItems)
+          if (filteredItems.length) {
+            acc[group] = filteredItems
+          }
+
+          return acc
+        }, {})
+
+        // Flatten the grouped options while maintaining their order
+        return Object.values(filteredGroups).flat()
+      }}
       renderOption={(props, option, { selected }) => {
         const { key, ...optionProps } = props
 

--- a/src/components/generic/AutocompleteCheckbox.jsx
+++ b/src/components/generic/AutocompleteCheckbox.jsx
@@ -62,7 +62,6 @@ const AutocompleteCheckbox = ({
             keys: [(item) => item],
           })
 
-          console.log('filteredItems ', filteredItems)
           if (filteredItems.length) {
             acc[group] = filteredItems
           }


### PR DESCRIPTION
Trello: https://trello.com/c/Q7uyZOG8/1174-remove-label-for-orgs-based-on-current-filters-when-there-are-no-filters-applied

- Refactor grouping and match sorter filter ordering.
- Remove label for Orgs based on current filters when there are no filters applied.