### PR TITLE
[M1176] Prevent too much zooming when zooming to a single survey

### DIFF
--- a/src/components/MapAndTableControls/MapAndTableControls.jsx
+++ b/src/components/MapAndTableControls/MapAndTableControls.jsx
@@ -88,7 +88,7 @@ const MapAndTableControls = ({ map = undefined, view, setView }) => {
     }
 
     const bounds = bbox(points(coordinates))
-    map.fitBounds(bounds)
+    map.fitBounds(bounds, { maxZoom: 17, padding: 20 })
   }
 
   return (

--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -208,8 +208,16 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
     if (!map || !displayedProjects || displayedProjects.length === 0) {
       return
     }
+
+    const normalizeLongitudeWithinRange = (lon) => {
+      return (lon + 360) % 360
+    }
+
     const coordinates = displayedProjects.flatMap((project) =>
-      project.records.map((record) => [record.longitude, record.latitude]),
+      project.records.map((record) => {
+        const newLon = normalizeLongitudeWithinRange(record.longitude)
+        return [newLon, record.latitude]
+      }),
     )
 
     if (coordinates.length === 0) {
@@ -217,7 +225,7 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
     }
 
     const bounds = bbox(points(coordinates))
-    map.fitBounds(bounds)
+    map.fitBounds(bounds, { maxZoom: 17, padding: 20 })
   }
 
   const handleFollowScreen = (e) => {


### PR DESCRIPTION
Add max zoom when filter to avoid no data available for single project filter.

Trello: https://trello.com/c/k6e67UIA/1176-prevent-too-much-zooming-when-zooming-to-a-single-survey