### PR TITLE
[M1175] Prevent long project names from breaking lines

### DIFF
--- a/src/components/TableView/TableView.jsx
+++ b/src/components/TableView/TableView.jsx
@@ -37,6 +37,9 @@ const StyledTableContainer = styled.div`
 `
 
 const StyledTr = styled(Tr)`
+  & > td:first-of-type {
+    overflow-wrap: break-word;
+  }
   ${({ $isSelected }) =>
     $isSelected
       ? css`


### PR DESCRIPTION
Add over flow wrap for project names row item in table.

Trello: https://trello.com/c/1kbXFrks/1175-prevent-long-project-names-from-breaking-lines