### PR TITLE
[M1243] Api calls twice after cache is clear

### DIFF
--- a/src/components/MermaidDash/MermaidDash.jsx
+++ b/src/components/MermaidDash/MermaidDash.jsx
@@ -149,37 +149,20 @@ const MermaidDash = ({ isApiDataLoaded, setIsApiDataLoaded }) => {
   }, [getAccessTokenSilently, setMermaidUserData])
 
   const _fetchDataFromApi = useEffect(() => {
-    const handleFetchData = async () => {
+    const handleFetchDataFromApi = async () => {
+      if (isLoading) return
+
       try {
         const token = isAuthenticated ? await getAccessTokenSilently() : ''
-        fetchData(token)
-        if (isAuthenticated) {
-          fetchUserProfile()
-          const profileEndpoint = `${import.meta.env.VITE_REACT_APP_AUTH0_AUDIENCE}/v1/me/`
-          const response = await fetch(
-            profileEndpoint,
-            await getAuthorizationHeaders(getAccessTokenSilently),
-          )
-          const parsedResponse = await response.json()
-          setMermaidUserData(parsedResponse)
-        }
-      } catch (e) {
-        console.error('Error fetching data:', e)
+        await fetchData(token)
+        await fetchUserProfile()
+      } catch (error) {
+        console.error('Error fetching data:', error)
       }
     }
 
-    if (isLoading) {
-      return
-    }
-    handleFetchData()
-  }, [
-    isLoading,
-    isAuthenticated,
-    getAccessTokenSilently,
-    fetchUserProfile,
-    fetchData,
-    setMermaidUserData,
-  ])
+    handleFetchDataFromApi()
+  }, [isLoading, isAuthenticated, getAccessTokenSilently, fetchData, fetchUserProfile])
 
   const updateURLParams = useCallback(
     (queryParams) => {


### PR DESCRIPTION
**Done:**

- Refactored the useEffect responsible for fetching API data.
- Removed a redundant fetchUserProfile call.

**Observation:**

- This does not fully resolve the issue of the API being called twice after clearing the cache in login mode.
- The app intentionally allows fetching data when the token is empty (or isAuthenticated is false) so that:
1. It fetches data initially.
2. It fetches again once the login process completes.
- The double fetch only occurs when the cache is cleared; subsequent fetches work as expected.