### PR TITLE
[M1313] Column in download table should be the number of surveys selected in dropdown, not total for project.

### DIFF
--- a/src/helperFunctions/formatDownloadProjectDataHelper.js
+++ b/src/helperFunctions/formatDownloadProjectDataHelper.js
@@ -1,5 +1,8 @@
 import { DOWNLOAD_METHODS } from '../constants/constants'
 
+const getMethodSurveyCount = (projectRecords, selectedMethod) =>
+  projectRecords.filter((record) => record.protocols?.[selectedMethod]).length
+
 export const formatDownloadProjectDataHelper = (
   project,
   isMemberOfProject,
@@ -8,7 +11,7 @@ export const formatDownloadProjectDataHelper = (
 ) => {
   const methodDataSharing = DOWNLOAD_METHODS[selectedMethod]?.policy
   const dataSharingPolicy = project[methodDataSharing]
-  const surveyCount = project.records.length
+  const surveyCount = getMethodSurveyCount(project?.records || [], selectedMethod)
 
   if (isMemberOfProject) {
     return {


### PR DESCRIPTION
Trello: https://trello.com/c/sJNTHicr/1313-column-in-download-table-should-be-the-number-of-surveys-selected-in-dropdown-not-total-for-project?filter=label:dash%20app

https://github.com/user-attachments/assets/f1da050a-7628-400f-aeec-608009ce3510

