### PR TITLE
[M1387] Refactor modals layout and responsiveness

### DIFF
--- a/src/components/MermaidDash/components/DataSharingInfoModal.jsx
+++ b/src/components/MermaidDash/components/DataSharingInfoModal.jsx
@@ -172,6 +172,7 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
       onDismiss={onDismiss}
       footerContent={footerContent}
       contentOverflowIsVisible={true}
+      // The modalCustomWidth prop is commented out for now. Uncomment and set a value if custom width is needed in the future.
       // modalCustomWidth={'1000px'}
     />
   )

--- a/src/components/MermaidDash/components/DataSharingInfoModal.jsx
+++ b/src/components/MermaidDash/components/DataSharingInfoModal.jsx
@@ -2,16 +2,8 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 import { IconCheck, IconClose } from '../../../assets/icons'
-import {
-  Modal,
-  RightFooter,
-  ButtonSecondary,
-  Table,
-  Tr,
-  Th,
-  Td,
-  TableOverflowWrapper,
-} from '../../generic'
+import { Modal, RightFooter, ButtonSecondary, Tr, Th, Td } from '../../generic'
+import { ModalStickyTable, ModalTableOverflowWrapper } from '../../generic/table'
 
 const ModalBody = styled.div`
   padding-left: 2rem;
@@ -59,8 +51,8 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
 
   const modalContent = (
     <ModalBody>
-      <TableOverflowWrapper>
-        <Table>
+      <ModalTableOverflowWrapper $tableCustomHeight="735px">
+        <ModalStickyTable>
           <thead>
             <Tr>
               <StyledTh $width="550px" $alignLeft>
@@ -162,8 +154,8 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
               {greenIconCheck}
             </Tr>
           </tbody>
-        </Table>
-      </TableOverflowWrapper>
+        </ModalStickyTable>
+      </ModalTableOverflowWrapper>
     </ModalBody>
   )
   const footerContent = (
@@ -180,7 +172,7 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
       onDismiss={onDismiss}
       footerContent={footerContent}
       contentOverflowIsVisible={true}
-      modalCustomWidth={'1000px'}
+      // modalCustomWidth={'1000px'}
     />
   )
 }

--- a/src/components/MermaidDash/components/DataSharingInfoModal.jsx
+++ b/src/components/MermaidDash/components/DataSharingInfoModal.jsx
@@ -172,8 +172,6 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
       onDismiss={onDismiss}
       footerContent={footerContent}
       contentOverflowIsVisible={true}
-      // The modalCustomWidth prop is commented out for now. Uncomment and set a value if custom width is needed in the future.
-      // modalCustomWidth={'1000px'}
     />
   )
 }

--- a/src/components/MermaidDash/components/DownloadModal.jsx
+++ b/src/components/MermaidDash/components/DownloadModal.jsx
@@ -280,8 +280,6 @@ const DownloadModal = ({ isOpen, onDismiss, selectedMethod, handleSelectedMethod
       onDismiss={onDismiss}
       footerContent={footerContent}
       contentOverflowIsVisible={true}
-      modalCustomWidth={modalMode === 'download' ? '1150px' : '600px'}
-      modalCustomHeight={modalMode === 'download' ? '600px' : '200px'}
     />
   )
 }

--- a/src/components/MetricsPane/charts/HardCoralInfoModal.jsx
+++ b/src/components/MetricsPane/charts/HardCoralInfoModal.jsx
@@ -1,11 +1,19 @@
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+import { mediaQueryHeightMax680, mediaQueryWidthMax1280 } from '../../../styles/mediaQueries'
 import { Modal, RightFooter, ButtonSecondary } from '../../generic'
 
 const ModalBody = styled.div`
   padding-left: 2rem;
   padding-right: 2rem;
-  z-index: 2;
+  height: 500px;
+
+  ${mediaQueryWidthMax1280(css`
+    height: 400px;
+  `)};
+  ${mediaQueryHeightMax680(css`
+    height: 300px;
+  `)}
 `
 
 const HardCoralInfoModal = ({ isModalOpen, handleCloseModal }) => {
@@ -81,7 +89,6 @@ const HardCoralInfoModal = ({ isModalOpen, handleCloseModal }) => {
         title={modalTitle}
         mainContent={modalContent}
         footerContent={footerContent}
-        modalCustomHeight={'600px'}
       />
     </>
   )

--- a/src/components/generic/Modal.jsx
+++ b/src/components/generic/Modal.jsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import { IconClose } from '../../assets/icons'
 import theme from '../../styles/theme'
 import { CloseButton } from './buttons'
-import { mediaQueryPhoneOnly } from '../../styles/mediaQueries'
+import { mediaQuery960To1200, mediaQueryPhoneOnly } from '../../styles/mediaQueries'
 
 const StyledDialogOverlay = styled.div`
   background: rgba(0, 0, 0, 0.5);
@@ -21,13 +21,16 @@ const StyledDialogOverlay = styled.div`
 const StyledDialog = styled.div`
   padding: 0;
   margin: 0;
-  min-width: 30rem;
-  width: ${(props) => props.$modalCustomWidth};
-  max-width: 114rem;
+  min-width: 60rem;
+  width: ${(props) => props.$modalCustomWidth || 'auto'};
+  max-width: 110rem;
   background: ${theme.color.tableRowEven};
   ${(props) => props.$modalCustomHeight && `height: ${props.$modalCustomHeight};`}
   display: flex;
   flex-direction: column;
+  ${mediaQuery960To1200(css`
+    width: 850px;
+  `)}
   ${mediaQueryPhoneOnly(css`
     min-width: 35rem;
   `)}
@@ -130,7 +133,7 @@ const Modal = ({
   footerContent,
   contentOverflowIsVisible = false,
   toolbarContent = undefined,
-  modalCustomWidth = '50vw',
+  modalCustomWidth = '',
   modalCustomHeight = '',
   hideCloseIcon = false,
 }) => {

--- a/src/components/generic/table.js
+++ b/src/components/generic/table.js
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components'
 import {
   hoverState,
+  mediaQueryHeightMax680,
   mediaQueryPhoneOnly,
   mediaQueryTabletLandscapeOnly,
 } from '../../styles/mediaQueries'
@@ -112,7 +113,11 @@ export const StickyTableOverflowWrapper = styled(TableOverflowWrapper)`
 
 export const ModalTableOverflowWrapper = styled(TableOverflowWrapper)`
   overflow: auto;
-  height: 400px;
+  height: ${(props) => props.$tableCustomHeight || '400px'};
+
+  ${mediaQueryHeightMax680(css`
+    height: 280px;
+  `)}
 `
 
 const stickyStyles = css`

--- a/src/styles/mediaQueries.js
+++ b/src/styles/mediaQueries.js
@@ -15,6 +15,19 @@ const mediaQueryTabletLandscapeOnly = (content) => css`
     ${content};
   }
 `
+
+const mediaQueryWidthMax1280 = (content) => css`
+  @media (max-width: 1280px) {
+    ${content};
+  }
+`
+
+const mediaQuery960To1200 = (content) => css`
+  @media (min-width: 960px) and (max-width: 1300px) {
+    ${content};
+  }
+`
+
 const mediaQueryForTabletLandscapeUp = (content) => css`
   @media (min-width: 900px) {
     ${content};
@@ -36,6 +49,12 @@ const mediaQueryForBigDesktopUp = (content) => css`
     ${content};
   }
 `
+
+const mediaQueryHeightMax680 = (content) => css`
+  @media (max-height: 680px) {
+    ${content};
+  }
+`
 const hoverState = (content) => css`
   @media (hover: hover) {
     &:hover:not([disabled]) {
@@ -48,9 +67,12 @@ export {
   mediaQueryPhoneOnly,
   mediaQueryForBigDesktopUp,
   mediaQueryForTabletLandscapeUp,
+  mediaQueryWidthMax1280,
+  mediaQuery960To1200,
   mediaQueryTabletLandscapeOnly,
   mediaQueryForTabletPortraitUp,
   mediaQueryForDesktopUp,
   mediaQueryForMediumDesktop,
+  mediaQueryHeightMax680,
   hoverState,
 }


### PR DESCRIPTION
All modals are more responsive now including: 
- Download Modal (Tablet & Desktop)
- Download GFCR Modal (Tablet & Desktop)
- Data Sharing Modal in Download Modal (Tablet & Desktop)
- Hard Coral Info Modal (Mobile, Tablet & Desktop)
- Share View Modal (Mobile, Tablet & Desktop)
- Other smaller modals including (Error fetching modal, No data for download modals) 
