### PR TITLE
fix: [M1482] Explore fish biomass time series x-axis issue

### DIFF
--- a/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
@@ -92,7 +92,6 @@ export const TimeSeriesFishBiomass = () => {
   const allSingleYear = plotlyDataConfiguration.every((data) => {
     const uniqueYears = new Set(data.x)
     return uniqueYears.size === 1
-    return uniqueYears.length === 1
   })
 
   const plotlyLayoutConfiguration = {

--- a/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
@@ -90,7 +90,8 @@ export const TimeSeriesFishBiomass = () => {
   }))
 
   const allSingleYear = plotlyDataConfiguration.every((data) => {
-    const uniqueYears = Array.from(new Set(data.x))
+    const uniqueYears = new Set(data.x)
+    return uniqueYears.size === 1
     return uniqueYears.length === 1
   })
 

--- a/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesFishBiomass.jsx
@@ -89,6 +89,11 @@ export const TimeSeriesFishBiomass = () => {
     hovertemplate: `${rule}<br>Year: %{x}<br>%{y:.0f} kg/ha<extra></extra>`,
   }))
 
+  const allSingleYear = plotlyDataConfiguration.every((data) => {
+    const uniqueYears = Array.from(new Set(data.x))
+    return uniqueYears.length === 1
+  })
+
   const plotlyLayoutConfiguration = {
     ...plotlyChartTheme.layout,
     xaxis: {
@@ -97,6 +102,7 @@ export const TimeSeriesFishBiomass = () => {
         ...plotlyChartTheme.layout.xaxis.title,
         text: 'Year',
       },
+      type: allSingleYear ? 'category' : 'linear',
     },
     yaxis: {
       ...plotlyChartTheme.layout.yaxis,


### PR DESCRIPTION
For 1 year range, show only that year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The x-axis scale in the fish biomass time series chart now adjusts automatically: it displays as a category axis when all data series represent a single year, and as a linear axis otherwise. This improves the clarity and accuracy of chart visualization based on the data shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->