### PR TITLE
fix: [M74] Time series chart for benthic % cover not showing for any project or benthic method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist-ssr
 *.local
 .env
 
+# Claude Code
+.claude/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/components/MetricsPane/charts/SampleEventBenthicPlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventBenthicPlot.jsx
@@ -6,7 +6,7 @@ import { MetricCardH3 } from '../MetricsPane.styles'
 import plotlyChartTheme from '../../../styles/plotlyChartTheme'
 import { PrivateChartView } from './PrivateChartView'
 import { useTranslation } from 'react-i18next'
-import { BENTHIC_COVER_API_KEY } from '../../../constants/constants'
+import { BENTHIC_COVER_KEY_TO_LABEL } from '../../../constants/constants'
 
 const chartTheme = plotlyChartTheme
 const benthicCoverCategories = Object.entries(chartTheme.chartCategoryType.benthicCoverColorMap)
@@ -18,7 +18,7 @@ export const SampleEventBenthicPlot = ({ benthicType, benthicData }) => {
 
   const benthicPercentageCover = benthicCoverCategories.map(([category, color]) => ({
     label: t(`chart_category.${category}`),
-    value: benthicPercentageData?.[BENTHIC_COVER_API_KEY[category]] ?? 0,
+    value: benthicPercentageData?.[BENTHIC_COVER_KEY_TO_LABEL[category]] ?? 0,
     color,
   }))
 

--- a/src/components/MetricsPane/charts/SampleEventBenthicPlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventBenthicPlot.jsx
@@ -6,22 +6,10 @@ import { MetricCardH3 } from '../MetricsPane.styles'
 import plotlyChartTheme from '../../../styles/plotlyChartTheme'
 import { PrivateChartView } from './PrivateChartView'
 import { useTranslation } from 'react-i18next'
+import { BENTHIC_COVER_API_KEY } from '../../../constants/constants'
 
 const chartTheme = plotlyChartTheme
 const benthicCoverCategories = Object.entries(chartTheme.chartCategoryType.benthicCoverColorMap)
-const benthicCoverApiKey = {
-  hard_coral: 'Hard coral',
-  bare_substrate: 'Bare substrate',
-  crustose_coralline_algae: 'Crustose coralline algae',
-  rubble: 'Rubble',
-  cyanobacteria: 'Cyanobacteria',
-  seagrass: 'Seagrass',
-  sand: 'Sand',
-  macroalgae: 'Macroalgae',
-  turf_algae: 'Turf algae',
-  soft_coral: 'Soft coral',
-  other_invertebrates: 'Other invertebrates',
-}
 
 export const SampleEventBenthicPlot = ({ benthicType, benthicData }) => {
   const { t } = useTranslation()
@@ -30,7 +18,7 @@ export const SampleEventBenthicPlot = ({ benthicType, benthicData }) => {
 
   const benthicPercentageCover = benthicCoverCategories.map(([category, color]) => ({
     label: t(`chart_category.${category}`),
-    value: benthicPercentageData?.[benthicCoverApiKey[category]] ?? 0,
+    value: benthicPercentageData?.[BENTHIC_COVER_API_KEY[category]] ?? 0,
     color,
   }))
 

--- a/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
@@ -10,7 +10,7 @@ import { PrivateChartView } from './PrivateChartView'
 import { NoDataChartView } from './NoDataChartView'
 import { pluralizeWordWithCount } from '../../../helperFunctions/pluralize'
 import { checkXSeriesYears } from '../../../helperFunctions/chartHelpers'
-import { BENTHIC_COVER_API_KEY } from '../../../constants/constants'
+import { BENTHIC_COVER_KEY_TO_LABEL } from '../../../constants/constants'
 
 const categories = Object.keys(plotlyChartTheme.chartCategoryType.benthicCoverColorMap)
 
@@ -47,7 +47,7 @@ export const TimeSeriesBenthicCover = () => {
         const avgBenthicCoverValues = Object.keys(recordProtocols)
           .map((protocol) => {
             const categoryData = recordProtocols[protocol]?.percent_cover_benthic_category_avg
-            return categoryData?.[BENTHIC_COVER_API_KEY[category]] ?? null
+            return categoryData?.[BENTHIC_COVER_KEY_TO_LABEL[category]] ?? null
           })
           .filter((val) => val !== null)
 
@@ -110,11 +110,11 @@ export const TimeSeriesBenthicCover = () => {
         x: validDistributions.map((distribution) => distribution.year),
         y: validDistributions.map((distribution) => distribution[category]),
         type: 'bar',
-        name: BENTHIC_COVER_API_KEY[category],
+        name: BENTHIC_COVER_KEY_TO_LABEL[category],
         marker: {
           color: plotlyChartTheme.chartCategoryType.benthicCoverColorMap[category],
         },
-        hovertemplate: `${BENTHIC_COVER_API_KEY[category]}<br>Year: %{x}<br>%{y:.1f}% cover<extra></extra>`,
+        hovertemplate: `${BENTHIC_COVER_KEY_TO_LABEL[category]}<br>Year: %{x}<br>%{y:.1f}% cover<extra></extra>`,
       }
     })
     .filter((trace) => trace.y.some((value) => value > 0))

--- a/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
@@ -10,6 +10,7 @@ import { PrivateChartView } from './PrivateChartView'
 import { NoDataChartView } from './NoDataChartView'
 import { pluralizeWordWithCount } from '../../../helperFunctions/pluralize'
 import { checkXSeriesYears } from '../../../helperFunctions/chartHelpers'
+import { BENTHIC_COVER_API_KEY } from '../../../constants/constants'
 
 const categories = Object.keys(plotlyChartTheme.chartCategoryType.benthicCoverColorMap)
 
@@ -46,7 +47,7 @@ export const TimeSeriesBenthicCover = () => {
         const avgBenthicCoverValues = Object.keys(recordProtocols)
           .map((protocol) => {
             const categoryData = recordProtocols[protocol]?.percent_cover_benthic_category_avg
-            return categoryData?.[category] ?? null
+            return categoryData?.[BENTHIC_COVER_API_KEY[category]] ?? null
           })
           .filter((val) => val !== null)
 
@@ -96,7 +97,7 @@ export const TimeSeriesBenthicCover = () => {
     },
   )
   const totalSurveys = benthicPercentageCoverDistributions
-    .filter((record) => isValidNumber(record['Hard coral']))
+    .filter((record) => isValidNumber(record['hard_coral']))
     .reduce((sum, { count }) => sum + count, 0)
 
   const plotlyDataConfiguration = categories

--- a/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
+++ b/src/components/MetricsPane/charts/TimeSeriesBenthicCover.jsx
@@ -110,11 +110,11 @@ export const TimeSeriesBenthicCover = () => {
         x: validDistributions.map((distribution) => distribution.year),
         y: validDistributions.map((distribution) => distribution[category]),
         type: 'bar',
-        name: category,
+        name: BENTHIC_COVER_API_KEY[category],
         marker: {
           color: plotlyChartTheme.chartCategoryType.benthicCoverColorMap[category],
         },
-        hovertemplate: `${category}<br>Year: %{x}<br>%{y:.1f}% cover<extra></extra>`,
+        hovertemplate: `${BENTHIC_COVER_API_KEY[category]}<br>Year: %{x}<br>%{y:.1f}% cover<extra></extra>`,
       }
     })
     .filter((trace) => trace.y.some((value) => value > 0))

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -155,7 +155,8 @@ export const POLICY_MAPPINGS = {
 export const MAP_VIEW = 'map view'
 export const TABLE_VIEW = 'table view'
 
-export const BENTHIC_COVER_API_KEY = {
+// Note: these labels duplicate the chart_category entries in src/locales/en/translation.json — consider consolidating
+export const BENTHIC_COVER_KEY_TO_LABEL = {
   hard_coral: 'Hard coral',
   bare_substrate: 'Bare substrate',
   crustose_coralline_algae: 'Crustose coralline algae',

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -154,3 +154,17 @@ export const POLICY_MAPPINGS = {
 
 export const MAP_VIEW = 'map view'
 export const TABLE_VIEW = 'table view'
+
+export const BENTHIC_COVER_API_KEY = {
+  hard_coral: 'Hard coral',
+  bare_substrate: 'Bare substrate',
+  crustose_coralline_algae: 'Crustose coralline algae',
+  rubble: 'Rubble',
+  cyanobacteria: 'Cyanobacteria',
+  seagrass: 'Seagrass',
+  sand: 'Sand',
+  macroalgae: 'Macroalgae',
+  turf_algae: 'Turf algae',
+  soft_coral: 'Soft coral',
+  other_invertebrates: 'Other invertebrates',
+}

--- a/src/helperFunctions/chartHelpers.js
+++ b/src/helperFunctions/chartHelpers.js
@@ -4,3 +4,4 @@ export const checkXSeriesYears = (plotlyData) => {
     return uniqueYears.size < 3
   })
 }
+


### PR DESCRIPTION
- Centralize benthic cover API key mappings
- Move benthic category API key mappings into constants and update benthic chart components to use the shared mapping for value lookup. Also fix time series survey counting to check `hard_coral` keys and ignore `.claude/` in git.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed benthic cover data filtering logic in time series visualization to correctly identify hard coral records.

* **Refactor**
  * Consolidated benthic cover category mappings into a centralized constant for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->