### PR TITLE
1974 macroinvertebrate e3

### DIFF
--- a/src/components/MermaidDash/components/ExportModal.jsx
+++ b/src/components/MermaidDash/components/ExportModal.jsx
@@ -256,6 +256,7 @@ ExportModal.propTypes = {
     colonies_bleached: PropTypes.number,
     habitatcomplexity: PropTypes.number,
     quadrat_benthic_percent: PropTypes.number,
+    macroinvertebrate: PropTypes.number,
   }).isRequired,
 }
 

--- a/src/components/MetricsPane/SelectedProjectMetrics.jsx
+++ b/src/components/MetricsPane/SelectedProjectMetrics.jsx
@@ -61,6 +61,7 @@ export const SelectedProjectMetrics = ({ selectedProject, setSelectedProject }) 
     data_policy_beltfish: dataSharingBeltfish,
     data_policy_benthiclit: dataSharingBenthiclit,
     data_policy_bleachingqc: dataSharingBleachingqc,
+    data_policy_macroinvertebrate: dataSharingMacroinvertebrate,
   } = selectedProject
   const protocolSurveyCounts = getProtocolSurveyCounts(selectedProject?.records)
 
@@ -206,7 +207,10 @@ export const SelectedProjectMetrics = ({ selectedProject, setSelectedProject }) 
         </ProjectCard>
       )}
 
-      {(dataSharingBeltfish || dataSharingBenthiclit || dataSharingBleachingqc) && (
+      {(dataSharingBeltfish ||
+        dataSharingBenthiclit ||
+        dataSharingBleachingqc ||
+        dataSharingMacroinvertebrate) && (
         <ProjectCard>
           <DataSharingIcon />
           <ProjectCardContent>
@@ -218,6 +222,8 @@ export const SelectedProjectMetrics = ({ selectedProject, setSelectedProject }) 
               <PolicyValue>{dataSharingBenthiclit}</PolicyValue>
               <PolicyType>Bleaching</PolicyType>
               <PolicyValue>{dataSharingBleachingqc}</PolicyValue>
+              <PolicyType>Macroinvertebrate</PolicyType>
+              <PolicyValue>{dataSharingMacroinvertebrate}</PolicyValue>
             </DataSharingGrid>
           </ProjectCardContent>
         </ProjectCard>

--- a/src/components/MetricsPane/SelectedSiteMetrics.jsx
+++ b/src/components/MetricsPane/SelectedSiteMetrics.jsx
@@ -73,6 +73,7 @@ import { SampleEventBleachingPlot } from './charts/SampleEventBleachingPlot'
 import { SampleEventBenthicPlot } from './charts/SampleEventBenthicPlot'
 import { SampleEventBleachingSeverityPlot } from './charts/SampleEventBleachingSeverityPlot'
 import { SampleEventHabitatComplexityPlot } from './charts/SampleEventHabitatComplexityPlot'
+import { SampleEventMacroinvertebratePlot } from './charts/SampleEventMacroinvertebratePlot'
 import ContactOrUserIcon from './ContactOrUserIcon'
 import HideShow from '../Header/components/HideShow'
 import SuccessExportModal from '../MermaidDash/components/SuccessExportModal'
@@ -111,6 +112,7 @@ export const SelectedSiteMetrics = ({
     data_policy_beltfish: dataPolicyBeltfish,
     data_policy_benthiclit: dataPolicyBenthiclit,
     data_policy_bleachingqc: dataPolicyBleachingqc,
+    data_policy_macroinvertebrate: dataPolicyMacroinvertebrate,
     suggested_citation: suggestedCitation,
     protocols,
   } = selectedSampleEvent
@@ -441,6 +443,13 @@ export const SelectedSiteMetrics = ({
                   />
                 </SelectedSiteChartWrapper>
               )}
+              {protocols?.macroinvertebrate && (
+                <SelectedSiteChartWrapper>
+                  <SampleEventMacroinvertebratePlot
+                    macroinvertebrateData={protocols?.macroinvertebrate}
+                  />
+                </SelectedSiteChartWrapper>
+              )}
             </ChartsWrapper>
           ) : (
             <>
@@ -491,7 +500,10 @@ export const SelectedSiteMetrics = ({
                   </StyledReefContainer>
                 </SelectedSiteContentContainer>
               </SelectedSiteMetricsCardContainer>
-              {(dataPolicyBeltfish || dataPolicyBenthiclit || dataPolicyBleachingqc) && (
+              {(dataPolicyBeltfish ||
+                dataPolicyBenthiclit ||
+                dataPolicyBleachingqc ||
+                dataPolicyMacroinvertebrate) && (
                 <SelectedSiteMetricsCardContainer>
                   <BiggerIconDataSharing />
                   <SelectedSiteContentContainer>
@@ -508,6 +520,10 @@ export const SelectedSiteMetrics = ({
                       <StyledReefRow>
                         <StyledReefItemBold>Bleaching</StyledReefItemBold>
                         <StyledReefItem>{dataPolicyBleachingqc}</StyledReefItem>
+                      </StyledReefRow>
+                      <StyledReefRow>
+                        <StyledReefItemBold>Macroinvertebrate</StyledReefItemBold>
+                        <StyledReefItem>{dataPolicyMacroinvertebrate}</StyledReefItem>
                       </StyledReefRow>
                     </StyledReefContainer>
                   </SelectedSiteContentContainer>

--- a/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
@@ -1,0 +1,94 @@
+import Plot from 'react-plotly.js'
+import PropTypes from 'prop-types'
+
+import { ChartSubtitle, ChartWrapper, HorizontalLine, TitlesWrapper } from './Charts.styles'
+import { MetricCardH3 } from '../MetricsPane.styles'
+import plotlyChartTheme from '../../../styles/plotlyChartTheme'
+import { PrivateChartView } from './PrivateChartView'
+import { useTranslation } from 'react-i18next'
+
+const chartTheme = plotlyChartTheme
+
+export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
+  const { t } = useTranslation()
+  const totalSampleUnits = macroinvertebrateData?.sample_unit_count ?? 0
+  const groupDensity = macroinvertebrateData?.density_indha_group_interest_avg ?? {}
+  const hasGroupDensityData = groupDensity && Object.keys(groupDensity).length > 0
+  const macroinvertebrateGroupLabels = Object.keys(groupDensity)
+  const formattedMacroinvertebrateGroupLabels = macroinvertebrateGroupLabels.map((label) =>
+    label.replace(' ', '<br>'),
+  )
+
+  const plotlyDataConfiguration = [
+    {
+      x: macroinvertebrateGroupLabels,
+      y: Object.values(groupDensity),
+      type: 'bar',
+      marker: {
+        color: Object.values(chartTheme.macroinvertebrate.groupColors),
+        line: { color: 'black', width: 1 },
+      },
+      xbins: {
+        size: 100,
+      },
+      hovertemplate: '%{x}<br>%{y:,.0f} ind/ha<extra></extra>',
+    },
+  ]
+
+  const plotlyLayoutConfiguration = {
+    ...chartTheme.layout,
+    margin: { ...chartTheme.layout.margin, t: 70, b: 80 },
+    xaxis: {
+      ...chartTheme.layout.xaxis,
+      tickangle: -45,
+      tickfont: { size: 9 },
+      tickmode: 'array',
+      tickvals: macroinvertebrateGroupLabels,
+      ticktext: formattedMacroinvertebrateGroupLabels,
+      title: {
+        ...chartTheme.layout.xaxis.title,
+        text: t('macroinvertebrate.group_of_interest_axis'),
+      },
+    },
+    yaxis: {
+      ...chartTheme.layout.yaxis,
+      title: {
+        ...chartTheme.layout.yaxis.title,
+        text: `${t('macroinvertebrate.density_axis')}`,
+      },
+    },
+  }
+
+  return (
+    <ChartWrapper>
+      <TitlesWrapper>
+        <MetricCardH3>{t('macroinvertebrate.title')}</MetricCardH3>
+        {hasGroupDensityData && (
+          <ChartSubtitle>
+            {totalSampleUnits === 1
+              ? t('sample_unit_one', { count: totalSampleUnits })
+              : t('sample_unit_other', { count: totalSampleUnits })}
+          </ChartSubtitle>
+        )}
+      </TitlesWrapper>
+      <HorizontalLine />
+      {hasGroupDensityData ? (
+        <Plot
+          data={plotlyDataConfiguration}
+          layout={plotlyLayoutConfiguration}
+          config={chartTheme.config}
+          style={{ width: '100%', height: '100%' }}
+        />
+      ) : (
+        <PrivateChartView />
+      )}
+    </ChartWrapper>
+  )
+}
+
+SampleEventMacroinvertebratePlot.propTypes = {
+  macroinvertebrateData: PropTypes.shape({
+    sample_unit_count: PropTypes.number,
+    density_indha_group_interest_avg: PropTypes.objectOf(PropTypes.number),
+  }).isRequired,
+}


### PR DESCRIPTION
Ref: https://trello.com/c/RWtEqdsN/1974-feature-macroinvertebrates-explore-per-project-per-site-and-export-integration-e3?filter=member%3Agiowan2

This PR adds macroinvertebrate to the per-project, per-site, and export views.

Per project
<img width="1163" height="839" alt="image" src="https://github.com/user-attachments/assets/a20acc4a-e556-444c-acfc-816745f2debf" />


Per site
<img width="1179" height="685" alt="image" src="https://github.com/user-attachments/assets/8b08028e-84c4-47ba-a58f-2e47e85c3694" />

Export
<img width="1177" height="678" alt="image" src="https://github.com/user-attachments/assets/f66a8968-de8c-419f-a43b-cf0685157a5c" />



## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added macroinvertebrate monitoring support with integrated data visualization and metrics
* Introduced macroinvertebrate density charts including aggregate, time series, and group-based views
* Added data sharing policy controls for macroinvertebrate data across projects and sites
* Extended metrics display to include macroinvertebrate data in relevant dashboard areas

<!-- end of auto-generated comment: release notes by coderabbit.ai -->