### PR TITLE
fix [m1972] add 'belt' to filter pane option

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -50,7 +50,7 @@ export const COLLECTION_METHODS = {
     dataSharingOptions: ['hc_all', 'hc_1', 'hc_2', 'hc_3'],
   },
   macroinvertebrate: {
-    description: 'Macroinvertebrate',
+    description: 'Macroinvertebrate Belt',
     dataSharingOptions: ['mi_all', 'mi_1', 'mi_2', 'mi_3'],
   },
 }


### PR DESCRIPTION
Ref: https://trello.com/c/B4kmjqfl/1972-feature-macroinvertebrate-explore-register-macroinvertebrate-in-constants-and-filter-pane-e1

<img width="367" height="289" alt="image" src="https://github.com/user-attachments/assets/7a43f575-5a58-449b-81bf-a48d6182a966" />

## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)