### PR TITLE
fix [m1974] sort density descending and others at end

### DIFF
--- a/src/components/MermaidDash/components/DataSharingInfoModal.jsx
+++ b/src/components/MermaidDash/components/DataSharingInfoModal.jsx
@@ -116,6 +116,15 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
             {greenIconCheck}
           </Tr>
           <Tr>
+            <StyledTd $alignLeft>
+              Average total macroinvertebrate density (ind/ha) and average macroinvertebrate density
+              per group of interest (ind/ha)
+            </StyledTd>
+            {redIconClose}
+            {greenIconCheck}
+            {greenIconCheck}
+          </Tr>
+          <Tr>
             <Td colSpan="4" $alignLeft>
               <strong>Transect-level observations</strong>
             </Td>
@@ -143,6 +152,15 @@ const DataSharingInfoModal = ({ isOpen, onDismiss }) => {
           </Tr>
           <Tr>
             <StyledTd $alignLeft>Colonies bleached and benthic percent cover</StyledTd>
+            {redIconClose}
+            {redIconClose}
+            {greenIconCheck}
+          </Tr>
+          <Tr>
+            <StyledTd $alignLeft>
+              Reef macroinvertebrate observation, size and count, density (ind/ha) per observation,
+              taxonomy and group of interest
+            </StyledTd>
             {redIconClose}
             {redIconClose}
             {greenIconCheck}

--- a/src/components/MetricsPane/SelectedProjectMetrics.jsx
+++ b/src/components/MetricsPane/SelectedProjectMetrics.jsx
@@ -222,7 +222,7 @@ export const SelectedProjectMetrics = ({ selectedProject, setSelectedProject }) 
               <PolicyValue>{dataSharingBenthiclit}</PolicyValue>
               <PolicyType>Bleaching</PolicyType>
               <PolicyValue>{dataSharingBleachingqc}</PolicyValue>
-              <PolicyType>Macroinvertebrate</PolicyType>
+              <PolicyType>Macroinvertebrate Belt</PolicyType>
               <PolicyValue>{dataSharingMacroinvertebrate}</PolicyValue>
             </DataSharingGrid>
           </ProjectCardContent>

--- a/src/components/MetricsPane/SelectedSiteMetrics.jsx
+++ b/src/components/MetricsPane/SelectedSiteMetrics.jsx
@@ -522,7 +522,7 @@ export const SelectedSiteMetrics = ({
                         <StyledReefItem>{dataPolicyBleachingqc}</StyledReefItem>
                       </StyledReefRow>
                       <StyledReefRow>
-                        <StyledReefItemBold>Macroinvertebrate</StyledReefItemBold>
+                        <StyledReefItemBold>Macroinvertebrate Belt</StyledReefItemBold>
                         <StyledReefItem>{dataPolicyMacroinvertebrate}</StyledReefItem>
                       </StyledReefRow>
                     </StyledReefContainer>

--- a/src/components/MetricsPane/SelectedSiteMetrics.styles.js
+++ b/src/components/MetricsPane/SelectedSiteMetrics.styles.js
@@ -114,14 +114,14 @@ export const StyledReefRow = styled.div`
   width: 100%;
 `
 export const StyledReefItem = styled.p`
-  width: 50%;
+  width: 45%;
   text-transform: capitalize;
   margin: 0;
 `
 
 export const StyledReefItemBold = styled(StyledReefItem)`
   font-weight: bold;
-  width: 50%;
+  width: 55%;
 `
 export const StyledVisibleBackground = styled.div`
   background-color: ${theme.color.grey1};

--- a/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
@@ -14,7 +14,23 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
   const totalSampleUnits = macroinvertebrateData?.sample_unit_count ?? 0
   const groupDensity = macroinvertebrateData?.density_indha_group_interest_avg ?? {}
   const hasGroupDensityData = groupDensity && Object.keys(groupDensity).length > 0
-  const macroinvertebrateGroupLabels = Object.keys(groupDensity)
+  const sortedMacroinvertebrateGroups = Object.entries(groupDensity)
+    .map(([label, value]) => ({ label, value }))
+    .sort((a, b) => {
+      const isOtherA = a.label.toLowerCase() === 'other invertebrates'
+      const isOtherB = b.label.toLowerCase() === 'other invertebrates'
+
+      if (isOtherA && !isOtherB) {
+        return 1
+      }
+      if (!isOtherA && isOtherB) {
+        return -1
+      }
+
+      return b.value - a.value
+    })
+  const macroinvertebrateGroupLabels = sortedMacroinvertebrateGroups.map((group) => group.label)
+  const macroinvertebrateGroupValues = sortedMacroinvertebrateGroups.map((group) => group.value)
   const formattedMacroinvertebrateGroupLabels = macroinvertebrateGroupLabels.map((label) =>
     label.replace(' ', '<br>'),
   )
@@ -22,10 +38,10 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
   const plotlyDataConfiguration = [
     {
       x: macroinvertebrateGroupLabels,
-      y: Object.values(groupDensity),
+      y: macroinvertebrateGroupValues,
       type: 'bar',
       marker: {
-        color: Object.values(chartTheme.macroinvertebrate.groupColors),
+        color: chartTheme.macroinvertebrate.groupColors,
         line: { color: 'black', width: 1 },
       },
       xbins: {

--- a/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
@@ -41,6 +41,7 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
   const totalDensityValue =
     macroinvertebrateData?.density_indha_avg ??
     macroinvertebrateGroupValues.reduce((sum, value) => sum + (Number(value) || 0), 0)
+  const formattedTotalDensityValue = Math.round(totalDensityValue).toLocaleString('en-US')
 
   const plotlyDataConfiguration = [
     {
@@ -89,7 +90,7 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
         xanchor: 'right',
         yanchor: 'top',
         showarrow: false,
-        text: `<b>${t('macroinvertebrate.total_density')}:</b> ${totalDensityValue.toFixed(1)} ind/ha`,
+        text: `<b>${t('macroinvertebrate.total_density')}:</b> ${formattedTotalDensityValue} ind/ha`,
         font: { size: 12, color: '#404040' },
       },
     ],

--- a/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventMacroinvertebratePlot.jsx
@@ -13,7 +13,7 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
   const { t } = useTranslation()
   const totalSampleUnits = macroinvertebrateData?.sample_unit_count ?? 0
   const groupDensity = macroinvertebrateData?.density_indha_group_interest_avg ?? {}
-  const hasGroupDensityData = groupDensity && Object.keys(groupDensity).length > 0
+  const hasGroupDensityData = Object.keys(groupDensity).length > 0
   const sortedMacroinvertebrateGroups = Object.entries(groupDensity)
     .map(([label, value]) => ({ label, value }))
     .sort((a, b) => {
@@ -31,9 +31,16 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
     })
   const macroinvertebrateGroupLabels = sortedMacroinvertebrateGroups.map((group) => group.label)
   const macroinvertebrateGroupValues = sortedMacroinvertebrateGroups.map((group) => group.value)
-  const formattedMacroinvertebrateGroupLabels = macroinvertebrateGroupLabels.map((label) =>
-    label.replace(' ', '<br>'),
+  const macroinvertebrateGroupColors = macroinvertebrateGroupLabels.map(
+    (_, index) =>
+      chartTheme.macroinvertebrate.groupColors[
+        index % chartTheme.macroinvertebrate.groupColors.length
+      ],
   )
+  const isDenseGroupChart = macroinvertebrateGroupLabels.length > 10
+  const totalDensityValue =
+    macroinvertebrateData?.density_indha_avg ??
+    macroinvertebrateGroupValues.reduce((sum, value) => sum + (Number(value) || 0), 0)
 
   const plotlyDataConfiguration = [
     {
@@ -41,11 +48,8 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
       y: macroinvertebrateGroupValues,
       type: 'bar',
       marker: {
-        color: chartTheme.macroinvertebrate.groupColors,
+        color: macroinvertebrateGroupColors,
         line: { color: 'black', width: 1 },
-      },
-      xbins: {
-        size: 100,
       },
       hovertemplate: '%{x}<br>%{y:,.0f} ind/ha<extra></extra>',
     },
@@ -53,14 +57,16 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
 
   const plotlyLayoutConfiguration = {
     ...chartTheme.layout,
-    margin: { ...chartTheme.layout.margin, t: 70, b: 80 },
+    margin: {
+      ...chartTheme.layout.margin,
+      t: 70,
+      b: 80,
+    },
     xaxis: {
       ...chartTheme.layout.xaxis,
-      tickangle: -45,
-      tickfont: { size: 9 },
-      tickmode: 'array',
-      tickvals: macroinvertebrateGroupLabels,
-      ticktext: formattedMacroinvertebrateGroupLabels,
+      automargin: true,
+      tickangle: isDenseGroupChart ? -60 : -45,
+      tickfont: { size: isDenseGroupChart ? 8 : 9 },
       title: {
         ...chartTheme.layout.xaxis.title,
         text: t('macroinvertebrate.group_of_interest_axis'),
@@ -68,11 +74,25 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
     },
     yaxis: {
       ...chartTheme.layout.yaxis,
+      automargin: true,
       title: {
         ...chartTheme.layout.yaxis.title,
         text: `${t('macroinvertebrate.density_axis')}`,
       },
     },
+    annotations: [
+      {
+        x: 1,
+        y: 1.07,
+        xref: 'paper',
+        yref: 'paper',
+        xanchor: 'right',
+        yanchor: 'top',
+        showarrow: false,
+        text: `<b>${t('macroinvertebrate.total_density')}:</b> ${totalDensityValue.toFixed(1)} ind/ha`,
+        font: { size: 12, color: '#404040' },
+      },
+    ],
   }
 
   return (
@@ -105,6 +125,7 @@ export const SampleEventMacroinvertebratePlot = ({ macroinvertebrateData }) => {
 SampleEventMacroinvertebratePlot.propTypes = {
   macroinvertebrateData: PropTypes.shape({
     sample_unit_count: PropTypes.number,
+    density_indha_avg: PropTypes.number,
     density_indha_group_interest_avg: PropTypes.objectOf(PropTypes.number),
   }).isRequired,
 }

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -87,7 +87,7 @@ export const EXPORT_METHODS = {
     policy: 'data_policy_habitatcomplexity',
   },
   macroinvertebrate: {
-    description: 'Macroinvertebrate',
+    description: 'Macroinvertebrate Belt',
     protocol: 'macroinvertebrate',
     policy: 'data_policy_macroinvertebrate',
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -50,9 +50,10 @@
   "macroinvertebrate": {
     "title": "Macroinvertebrate Density",
     "bin": "Bin",
+    "total_density": "Total density",
     "density_axis": "Macroinvertebrate density (ind/ha)",
     "surveys_axis": "Number of surveys",
-    "group_of_interest_axis": "Group of Interest",
+    "group_of_interest_axis": "Group of interest",
     "year_axis": "Year",
     "management_rule": "Management rule"
   },


### PR DESCRIPTION
Ref: https://trello.com/c/RWtEqdsN/1974-feature-macroinvertebrates-explore-per-project-per-site-and-export-integration-e3

- When there are more bars in the site summary chart, the y axis title has less spacing to the y axis (see screenshot). Spacing should stay the same regardless of number of groups. -> use yaxis auto margin
- The bars in the site summary macroinvert chart should be ordered from highest value to lowest value, and Other invertebrates always on the right end. See [this visualization](https://data-mermaid.github.io/analysis-explore-macroinvertebrate-visualizations/analysis_explore_macroinvertebrate_visualizations.html#barplot---densities-by-group-of-interest-single-survey) for example. -> will put into order
- The site summary macroinvert chart should include an annotation for Total density XXXX ind/ha on top right. See [this visualization](https://data-mermaid.github.io/analysis-explore-macroinvertebrate-visualizations/analysis_explore_macroinvertebrate_visualizations.html#barplot---densities-by-group-of-interest-single-survey) for example. - will add based on sample
- X axis title of site summary chart should be Group of interest without the “i” capitalized. - will do
- When there are many groups of interest some groups are not colored and are overlaid (see screenshot). - will define 8 colors and then loop them

Before for all of the above:
<img width="448" height="432" alt="image" src="https://github.com/user-attachments/assets/18cddb4a-7916-421c-9b87-e9f15049d471" />


After for all of the above:
<img width="406" height="420" alt="image" src="https://github.com/user-attachments/assets/1111507e-ecac-4dcb-a7a4-ca464ee3632e" />


- In the Metadata tab, under Data sharing, it should be Macroinvertebrate belt. Also, there should be more spacing between method name and data sharing option (see screenshot). -> gave more line width to the first item

<img width="398" height="176" alt="image" src="https://github.com/user-attachments/assets/b0f43614-b4ee-4697-8530-57ad04b39d87" />


- Macroinvertebrate method should be Macroinvertebrate belt in all instances in Explore, including in Export project data next to project name in site view and in Export data dropdown in the Filters panel (see screenshots).
<img width="391" height="442" alt="image" src="https://github.com/user-attachments/assets/b8b272f1-2812-4b57-9822-665c5c89854f" />
<img width="359" height="540" alt="image" src="https://github.com/user-attachments/assets/3b8d94ac-abc3-4db4-8630-d52b2ca361e5" />


- Data sharing table accessed from the tool tip next to each method in dropdown of Export data in Filters panel should include details on macroinvertebrate data. Copy is [here](https://docs.google.com/document/d/1aSqK7bIJ9R07rRRdMlisJLx8pDMY7bJ9-zBUQAyA-M4/edit?tab=t.busd00uekmkv).

<img width="1134" height="879" alt="image" src="https://github.com/user-attachments/assets/a0b4cc67-72d2-462a-a1c9-d925d2ae2805" />


## Every PR

Before merging, the developer of this pull request has checked the following:

- [x] Changes have been tested locally without errors
- [x] Lint has run and any errors have been resolved
- [x] Prettier has run on any changed files
- [x] Storybook stories have run and any errors have been resolved
- [x] Unit tests have been added or updated, where possible, to prevent future regressions
- [x] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more macroinvertebrate data-sharing details in the reef data-sharing modal.
  * Display now shows total macroinvertebrate density alongside group-level chart data.

* **Bug Fixes**
  * Improved macroinvertebrate chart ordering and color assignment for clearer display.
  * Chart layout now adapts better to larger numbers of groups.

* **Style**
  * Updated the Reef Habitat label to “Macroinvertebrate Belt.”
  * Adjusted spacing so reef-related labels fit more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->