### PR TITLE
feat: [M2042] Add total biomass label to fish biomass chart

### DIFF
--- a/src/components/MetricsPane/charts/SampleEventFishBiomassPlot.jsx
+++ b/src/components/MetricsPane/charts/SampleEventFishBiomassPlot.jsx
@@ -37,6 +37,11 @@ export const SampleEventFishBiomassPlot = ({ fishbeltData }) => {
     label.replace(' ', '<br>'),
   )
 
+  const totalBiomassValue =
+    fishbeltData?.biomass_kgha_avg ??
+    fishTropicGroupValues.reduce((sum, value) => sum + (Number(value) || 0), 0)
+  const formattedTotalBiomassValue = Math.round(totalBiomassValue).toLocaleString('en-US')
+
   const plotlyDataConfiguration = [
     {
       x: fishTropicGroupLabels,
@@ -72,6 +77,19 @@ export const SampleEventFishBiomassPlot = ({ fishbeltData }) => {
       ...chartTheme.layout.yaxis,
       title: { ...chartTheme.layout.yaxis.title, text: `${t('fish_biomass')} (kg/ha)` },
     },
+    annotations: [
+      {
+        x: 1,
+        y: 1.07,
+        xref: 'paper',
+        yref: 'paper',
+        xanchor: 'right',
+        yanchor: 'top',
+        showarrow: false,
+        text: `<b>${t('total_biomass')}:</b> ${formattedTotalBiomassValue} kg/ha`,
+        font: { size: 12, color: '#404040' },
+      },
+    ],
   }
 
   return (
@@ -100,6 +118,7 @@ export const SampleEventFishBiomassPlot = ({ fishbeltData }) => {
 SampleEventFishBiomassPlot.propTypes = {
   fishbeltData: PropTypes.shape({
     sample_unit_count: PropTypes.number,
+    biomass_kgha_avg: PropTypes.number,
     biomass_kgha_trophic_group_avg: PropTypes.shape({
       omnivore: PropTypes.number,
       piscivore: PropTypes.number,

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -47,6 +47,7 @@
     "send_email_failed": "Failed to send email. Please try again."
   },
   "fish_biomass": "Fish Biomass",
+  "total_biomass": "Total biomass",
   "macroinvertebrate": {
     "title": "Macroinvertebrate Density",
     "bin": "Bin",


### PR DESCRIPTION
Restores the "Total biomass" figure on the Explore fish biomass chart. It was present in the old (v1) dashboard but was not carried over during the v2 chart rework.

The chart now shows a **`Total biomass: 1,462 kg/ha`** annotation in the top-right, reading `biomass_kgha_avg` from the beltfish protocol (falling back to the sum of trophic-group values when absent). Styling and rounding deliberately match the existing macroinvertebrate "Total density" label so the two Explore charts stay consistent.

Note on rounding: values round to the nearest whole number (e.g. `1461.5` → `1,462`), matching the macroinvertebrate label. Happy to switch to a decimal if preferred.

### Changes
- `SampleEventFishBiomassPlot.jsx`: compute total biomass and render it as a Plotly annotation; add `biomass_kgha_avg` to propTypes.
- `translation.json`: add `total_biomass` key.

## Every PR

Before merging, the developer of this pull request has checked the following:

- [ ] Changes have been tested locally without errors
- [ ] Lint has run and any errors have been resolved
- [ ] Prettier has run on any changed files
- [ ] Storybook stories have run and any errors have been resolved
- [ ] Unit tests have been added or updated, where possible, to prevent future regressions
- [ ] Pre-existing unit tests have run and passed

## Post-Merge

- [ ] Code has merged and build success is confirmed in 'Actions'
- [ ] The corresponding Trello ticket has moved to the appropriate list (likely User-QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Total biomass” label above the fish biomass chart.
  * The chart now shows a total biomass value using available summary data, with a fallback calculation when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->